### PR TITLE
Add --crossgen flag.

### DIFF
--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace ManagedCodeGen
 {
-    public class corediff
+    public class jitdiff
     {
         // Supported commands.  List to view information from the CI system, and Copy to download artifacts.
         public enum Commands


### PR DESCRIPTION
More specifically allows for use of a particular tool, and be default
is untagged (as --base and --diff's output is default tagged "base"
and "diff" respectivly.  --crossgen allows for directly placeing a
particular dasm file.  This functionality is used in the runtest script
to build up the dasm output.