### PR TITLE
Update jitutils to use NETCore.App 1.0.0

### DIFF
--- a/src/cijobs/project.json
+++ b/src/cijobs/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.0-rc3-004465-00",
+    "Microsoft.NETCore.App": "1.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24210-10",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
     "System.CommandLine": "0.1.0-*",
@@ -18,6 +18,7 @@
   "runtimes": {
       "win81-x64": {},
       "ubuntu.14.04-x64": {},
+      "ubuntu.16.04-x64": {},
       "fedora.23-x64": {},
       "osx.10.10-x64": {},
       "osx.10.11-x64": {} 

--- a/src/jit-analyze/project.json
+++ b/src/jit-analyze/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.0-rc3-004465-00",
+    "Microsoft.NETCore.App": "1.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24210-10",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
     "System.CommandLine": "0.1.0-*",
@@ -18,6 +18,7 @@
   "runtimes": {
       "win81-x64": {},
       "ubuntu.14.04-x64": {}, 
+      "ubuntu.16.04-x64": {},
       "fedora.23-x64": {},
       "osx.10.10-x64": {},
       "osx.10.11-x64": {} 

--- a/src/jit-dasm/project.json
+++ b/src/jit-dasm/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.App": "1.0.0-rc3-004465-00",
+        "Microsoft.NETCore.App": "1.0.0",
         "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
         "System.CommandLine": "0.1.0-*"
     },
@@ -19,6 +19,7 @@
     "runtimes" : { 
         "win81-x64": {}, 
         "ubuntu.14.04-x64": {},
+        "ubuntu.16.04-x64": {},
         "fedora.23-x64": {},
         "osx.10.10-x64": {},
         "osx.10.11-x64": {} 

--- a/src/jit-diff/project.json
+++ b/src/jit-diff/project.json
@@ -5,7 +5,7 @@
   },
   
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.0-rc3-004465-00",
+    "Microsoft.NETCore.App": "1.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24210-10",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
     "System.CommandLine": "0.1.0-*",
@@ -21,6 +21,7 @@
   "runtimes": {
       "win81-x64": {},
       "ubuntu.14.04-x64": {}, 
+      "ubuntu.16.04-x64": {}, 
       "fedora.23-x64": {},
       "osx.10.10-x64": {},
       "osx.10.11-x64": {} 

--- a/src/packages/project.json
+++ b/src/packages/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.0-rc3-004465-00"
+    "Microsoft.NETCore.App": "1.0.0"
   },
   "frameworks": {
     "netcoreapp1.0": {
@@ -16,6 +16,7 @@
   "runtimes": { 
       "win81-x64": {}, 
       "ubuntu.14.04-x64": {},
+      "ubuntu.16.04-x64": {},
       "fedora.23-x64": {},
       "osx.10.10-x64": {},
       "osx.10.11-x64": {} 


### PR DESCRIPTION
Changes needed project.json to point to the RTM meta-package.  Additionally adds ubuntu-16.4.