### PR TITLE
Portable apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ To prepare the tools for use, from the root of the cloned jitutils repo, do the 
  2. Build and publish the tools: `build.{cmd|sh} -f -p`
 
 This will create the following directories in the repo root:
- 1. `bin` - contains one directory for each built tool.
+ 1. `bin` - contains built tools and wrapper scrips to drive them on the commandline.
  2. `fx` - contains a set of frameworks assemblies that can be used for asm diffs.
 
-Add each tool subdirectory to your path so you can easily invoke them, e.g.:
+To enable tools on the commandline just add the `bin` directory to the path.
 ```
 set jitutils=<path to root of jitutils clone>
-set PATH=%PATH%;%jitutils%\bin\jit-dasm;%jitutils%\bin\jit-diff;%jitutils%\bin\jit-analyze
+set PATH=%PATH%;%jitutils%\bin
 ```
 
 For a more complete introduction look at the [getting started guide](doc/getstarted.md).

--- a/build.cmd
+++ b/build.cmd
@@ -55,7 +55,8 @@ set projects=jit-diff jit-dasm jit-analyze cijobs
 REM Build each project
 for %%p in (%projects%) do (
     if %publish%==true (
-        dotnet publish -c %buildType% -o %appInstallDir%\%%p .\src\%%p
+        dotnet publish -c %buildType% -o %appInstallDir% .\src\%%p
+        copy .\wrapper.cmd %appInstallDir%\%%p.cmd
     ) else (
         dotnet build  -c %buildType% .\src\%%p
     )

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,8 @@ declare -a projects=(jit-dasm jit-diff jit-analyze cijobs)
 for proj in "${projects[@]}"
 do
     if [ "$publish" == true ]; then
-        dotnet publish -c $buildType -o $appInstallDir/$proj ./src/$proj
+        dotnet publish -c $buildType -o $appInstallDir ./src/$proj
+        cp ./wrapper.sh $appInstallDir/$proj
     else
         dotnet build -c $buildType ./src/$proj
     fi

--- a/doc/getstarted.md
+++ b/doc/getstarted.md
@@ -37,9 +37,9 @@ the developer in one shot.
 
 To build jitutils using the build script in the root of the repo: `build.{cmd,sh}`. By
 default the script just builds the tools and does not publish them in a separate directory.
-To publish the utilities add the '-p' flag which publishes each utility as a standalone app
-in a directory under ./bin in the root of the repo.  Additionally, to download the default set
-of framework assemblies that can be used for generating asm diffs, add '-f'.
+To publish the utilities add the '-p' flag which publishes each utility to the ./bin directory 
+in the root of the repo.  Additionally, to download the default set of framework assemblies 
+that can be used for generating asm diffs, add '-f'.
 
 ```
  $ ./build.sh -h

--- a/src/cijobs/project.json
+++ b/src/cijobs/project.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "debugType": "portable",
     "emitEntryPoint": true
   },
   "dependencies": {
@@ -12,15 +13,13 @@
   },
   "frameworks": {
     "netcoreapp1.0": {
+        "dependencies": {
+            "Microsoft.NETCore.App": {
+                "type": "platform",
+                "version": "1.0.0"
+            }
+        },
         "imports": "dnxcore50"
     }
-  },
-  "runtimes": {
-      "win81-x64": {},
-      "ubuntu.14.04-x64": {},
-      "ubuntu.16.04-x64": {},
-      "fedora.23-x64": {},
-      "osx.10.10-x64": {},
-      "osx.10.11-x64": {} 
   }
 }

--- a/src/jit-analyze/README.md
+++ b/src/jit-analyze/README.md
@@ -8,7 +8,7 @@ To build/setup:
 
 * Download dotnet cli.  Follow install instructions and get dotnet on your
   your path.
-* Follow publish directions for the mcgutils repo in the root.  This will 
+* Follow publish directions for the jitutils repo in the root.  This will 
   put the tools on your path.
 * Generate corediff disasm run.  See [Getting Started](../../doc/getstarted.md) 
   for directions how.

--- a/src/jit-analyze/project.json
+++ b/src/jit-analyze/project.json
@@ -1,10 +1,10 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "debugType": "portable",
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24210-10",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
     "System.CommandLine": "0.1.0-*",
@@ -12,15 +12,13 @@
   },
   "frameworks": {
     "netcoreapp1.0": {
+        "dependencies": {
+            "Microsoft.NETCore.App": {
+                "type": "platform",
+                "version": "1.0.0"
+            }
+        },
         "imports": "dnxcore50"
     }
-  },
-  "runtimes": {
-      "win81-x64": {},
-      "ubuntu.14.04-x64": {}, 
-      "ubuntu.16.04-x64": {},
-      "fedora.23-x64": {},
-      "osx.10.10-x64": {},
-      "osx.10.11-x64": {} 
   }
 }

--- a/src/jit-dasm/README.md
+++ b/src/jit-dasm/README.md
@@ -10,7 +10,7 @@ To build/setup:
   your path.
 * Do 'dotnet restore' to create lock file and 
   pull down required packages.
-* Issue a 'dotnet build' command.  This will create a jit-dasm.exe in the bin
+* Issue a 'dotnet build' command.  This will create a jit-dasm in the bin
   directory that you can use to drive creation of diffs.
 * jit-dasm can be installed by running the project build script in the root of this repo 
 via

--- a/src/jit-dasm/project.json
+++ b/src/jit-dasm/project.json
@@ -1,27 +1,24 @@
 ﻿{
     "version": "1.0.0-*",
     "buildOptions": {
+        "debugType": "portable",
         "emitEntryPoint": true
     },
 
     "dependencies": {
-        "Microsoft.NETCore.App": "1.0.0",
         "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
         "System.CommandLine": "0.1.0-*"
     },
 
     "frameworks": {
         "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                "type": "platform",
+                "version": "1.0.0"
+                }
+            },
             "imports": "dnxcore50"
         }
-    },
-    
-    "runtimes" : { 
-        "win81-x64": {}, 
-        "ubuntu.14.04-x64": {},
-        "ubuntu.16.04-x64": {},
-        "fedora.23-x64": {},
-        "osx.10.10-x64": {},
-        "osx.10.11-x64": {} 
     }
 }

--- a/src/jit-diff/README.md
+++ b/src/jit-diff/README.md
@@ -9,11 +9,11 @@ To build/setup:
   your path.
 * Do 'dotnet restore' to create lock file and 
   pull down required packages.
-* Issue a 'dotnet build' command.  This will create a mcgdiff.dll in the bin
+* Issue a 'dotnet build' command.  This will create a jit-diff in the bin
   directory that you can use to drive creation of diffs.
 * Ensure that jit-dasm is on your path.  (See jit-dasm README.md for details
   on how to build)
-* invoke jit-diff.exe --frameworks --base `<base crossgen>` --diff `<diff crossgen>` 
+* invoke jit-diff --frameworks --base `<base crossgen>` --diff `<diff crossgen>` 
   --coreroot `<path to core_root>` --testroot `<path to test_root>`
 * jit-diff can be installed by running the project build script in the root of this repo 
 via

--- a/src/jit-diff/project.json
+++ b/src/jit-diff/project.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "debugType": "portable",
     "emitEntryPoint": true
   },
   
@@ -14,16 +15,13 @@
   
   "frameworks": {
     "netcoreapp1.0": {
-        "imports": "dnxcore50"
+      "dependencies": {
+          "Microsoft.NETCore.App": {
+              "type": "platform",
+              "version": "1.0.0"
+          }
+      },
+      "imports": "dnxcore50"
     }
-  },
-  
-  "runtimes": {
-      "win81-x64": {},
-      "ubuntu.14.04-x64": {}, 
-      "ubuntu.16.04-x64": {}, 
-      "fedora.23-x64": {},
-      "osx.10.10-x64": {},
-      "osx.10.11-x64": {} 
   }
 }

--- a/wrapper.cmd
+++ b/wrapper.cmd
@@ -1,0 +1,2 @@
+@echo off
+dotnet.exe %~pn0.dll %*

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+SOURCE=$BASH_SOURCE
+dotnet $SOURCE.dll $@


### PR DESCRIPTION
Moves all jit utils to a flat directory of portable apps with script wrappers for invocation.

Portable apps are DLLs that have only MSIL and are invoked with 'dotnet.exe'.  Moving portable apps allows us to share the dotnet framework and only include a single directory on the path but requires wrapper scripts to hide the dotnet <mytool>.dll <args> command line.