### PR TITLE
Adds relative to full path expansion for '--crossgen' flag.

### DIFF
--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -143,6 +143,20 @@ namespace ManagedCodeGen
                 }
             }
 
+            if (_crossgenExe != null)
+            {
+                if (!File.Exists(_crossgenExe))
+                {
+                    _syntaxResult.ReportError("Can't find --crossgen tool.");
+                }
+                else
+                {
+                    // Set to full path for command resolution logic.
+                    string fullCrossgenPath = Path.GetFullPath(_crossgenExe);
+                    _crossgenExe = fullCrossgenPath;
+                }
+            }
+
             if (_fileName != null)
             {
                 if (!File.Exists(_fileName))


### PR DESCRIPTION
When the flag was addied the expansion was left out.  This change addes it in the same way as the --base or --diff flag does.