### PR TITLE
Fix path setting in bootstrap scripts

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -22,8 +22,5 @@ popd
 
 :: set utilites in the current path
 
-set PATH=%PATH%;%root%\jitutils\bin\jit-dasm;%root%\jitutils\bin\jit-diff;%root%\jitutils\bin\jit-analyze;%root%\jitutils\bin\cijobs
+set PATH=%PATH%;%root%\jitutils\bin
 
-:: lunch getstarted.md doc
-
-start https://github.com/dotnet/jitutils/blob/master/doc/getstarted.md

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,10 +30,6 @@ popd
 
 # set utilites in the current path
 
-export PATH=$PATH:$root/jitutils/bin/jit-dasm:$root/jitutils/bin/jit-diff:$root/jitutils/bin/jit-analyze:$root/jitutils/bin/cijobs
-
-# launch getstarted.md doc
-
-open https://github.com/dotnet/jitutils/blob/master/doc/getstarted.md
+export PATH=$PATH:$root/jitutils/bin
 
 echo "Done setting up!"


### PR DESCRIPTION
The bootstrap scripts are meant to set the PATH to include the path to the
jitutils executables. However, the way the export/set commands are
written, we attempt to add the actual executable to the path, rather than
the path to the executable ($root/jitutils/bin/jit-diff instead of
$root/jitutils/bin). This change updates the command so that when the user
runs the bootstrap scripts, the correct path is added to PATH, and the
user can just run the utilities without using their full path name.