### PR TITLE
Add approximate overload counts to the "top N" methods lists

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -393,7 +393,8 @@ namespace ManagedCodeGen
                                         {
                                             path = fd.path,
                                             name = md.name,
-                                            deltaBytes = md.deltaBytes
+                                            deltaBytes = md.deltaBytes,
+                                            count = md.baseOffsets != null ? md.baseOffsets.Count() : 1
                                         }).OrderByDescending(x => x.deltaBytes).ToList();
             int sortedMethodCount = sortedMethodDelta.Count();
             int methodCount = (sortedMethodCount < requestedCount)
@@ -405,7 +406,12 @@ namespace ManagedCodeGen
                 foreach (var method in sortedMethodDelta.GetRange(0, methodCount)
                                                         .Where(x => x.deltaBytes > 0))
                 {
-                    Console.WriteLine("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
+                    Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
+                    if (method.count > 1)
+                    {
+                        Console.Write(" ({0} methods)", method.count);
+                    }
+                    Console.WriteLine();
                 }
             }
 
@@ -419,7 +425,12 @@ namespace ManagedCodeGen
                                                         .Where(x => x.deltaBytes < 0)
                                                         .OrderBy(x => x.deltaBytes))
                 {
-                    Console.WriteLine("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
+                    Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
+                    if (method.count > 1)
+                    {
+                        Console.Write(" ({0} methods)", method.count);
+                    }
+                    Console.WriteLine();
                 }
             }
 


### PR DESCRIPTION
Jit diffs are unable to disambiguate some kinds of overloads because types
are mapped into a simplified set (ref, struct, etc). This can make
interpreting the total bytes of diff per method a bit tricky since the
entry may represent the total change from a set of methods. So, report on
how many folded overloads there are in the BASE set.

Example:
```
Top method improvements by size (bytes):
       -2801 : System.Private.CoreLib.dasm - System.Array:LastIndexOf(ref,struct,int,int):int (9 methods)
       -2328 : System.Private.CoreLib.dasm - System.Array:Sort(ref,int,int,ref) (25 methods)
```