### PR TITLE
Download clang-format/clang-tidy if not on PATH

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -19,6 +19,34 @@ dotnet restore
 
 call .\build.cmd -p -f
 
+where /Q clang-format
+IF %errorlevel% NEQ 0 GOTO DownloadTools
+
+where /Q clang-tidy
+IF %errorlevel% NEQ 0 GOTO DownloadTools
+
+GOTO CheckVersion
+
+:DownloadTools
+
+:: Download clang-format and clang-tidy
+echo Downloading formatting tools
+call powershell Invoke-WebRequest -Uri "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-format.exe" -OutFile bin\clang-format.exe
+call powershell Invoke-WebRequest -Uri "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-tidy.exe" -OutFile bin\clang-tidy.exe
+
+:CheckVersion
+
+clang-format --version | findstr 3.8 > NUL
+If %errorlevel% EQU 0 GOTO SetPath
+
+echo jit-format requires clang-format and clang-tidy version 3.8.*. Currently installed:
+clang-format --version
+clang-tidy --version
+echo Please install version 3.8.* and put the tools on the PATH to use jit-format.
+echo Tools can be found at http://llvm.org/releases/download.html#3.8.0
+
+:SetPath
+
 popd
 
 :: set utilites in the current path

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -26,6 +26,50 @@ dotnet restore
 
 ./build.sh -p -f
 
+if ! which -s clang-format || ! which -s clang-tidy;
+then
+
+    info=$(dotnet --info)
+
+    if echo $info | grep -q -i 'osx';
+    then
+        echo "Downloading clang-tidy and clang-format to bin directory"
+        # download osx version of clang-tidy/format
+        wget https://clrjit.blob.core.windows.net/clang-tools/osx/clang-format.exe -O bin/clang-format.exe
+        wget https://clrjit.blob.core.windows.net/clang-tools/osx/clang-tidy.exe -O bin/clang-tidy.exe
+    elif echo $info | grep -q -i 'ubuntu.16.04';
+    then
+        echo "Downloading clang-tidy and clang-format to bin directory"
+        # download osx version of clang-tidy/format
+        wget https://clrjit.blob.core.windows.net/clang-tools/ubuntu/16.04/clang-format.exe -O bin/clang-format.exe
+        wget https://clrjit.blob.core.windows.net/clang-tools/ubuntu/16.04/clang-tidy.exe -O bin/clang-tidy.exe
+    elif echo $info | grep -q -i 'ubuntu';
+    then
+        echo "Downloading clang-tidy and clang-format to bin directory"
+        # download osx version of clang-tidy/format
+        wget https://clrjit.blob.core.windows.net/clang-tools/ubuntu/14.04/clang-format.exe -O bin/clang-format.exe
+        wget https://clrjit.blob.core.windows.net/clang-tools/ubuntu/14.04/clang-tidy.exe -O bin/clang-tidy.exe
+    elif echo $info | grep -q -i 'centos';
+    then
+        echo "Downloading clang-tidy and clang-format to bin directory"
+        # download osx version of clang-tidy/format
+        wget https://clrjit.blob.core.windows.net/clang-tools/centos/clang-format.exe -O bin/clang-format.exe
+        wget https://clrjit.blob.core.windows.net/clang-tools/centos/clang-tidy.exe -O bin/clang-tidy.exe
+    else
+        echo "Clang-tidy and clang-format were not installed. Please install and put them on the PATH to use jit-format."
+        echo "Tools can be found at http://llvm.org/releases/download.html#3.8.0"
+    fi
+fi
+
+if ! clang-format --version | grep -q 3.8;
+then
+    echo "jit-format requires clang-format and clang-tidy version 3.8.*. Currently installed: "
+    clang-format --version
+    clang-tidy --version
+    echo "Please install version 3.8.* and put the tools on the PATH to use jit-format."
+    echo "Tools can be found at http://llvm.org/releases/download.html#3.8.0"
+fi
+
 popd
 
 # set utilites in the current path


### PR DESCRIPTION
This change updates boostrap.cmd/sh to install clang-format/clang-tidy
if they are not currently on the PATH. We then check the version of the
tools that are installed to confirm that version 3.8.* is installed. If
the wrong version is installed, boostrap.cmd/sh will inform the user
that jit-format requires 3.8.*, and will direct them to LLVM.org to
install the appropriate version.

We currently have downloads of the tools on Azure blob storage for
Ubuntu 14.04, Ubuntu 16.04, OSX, CentOS, and Windows. On other operating
systems, we direct the user to LLVM.org to install the appropriate
version for their platform.