### PR TITLE
Fix SetPlatform() and bootstrap for Linux platforms

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -34,6 +34,8 @@ echo Downloading formatting tools
 call powershell Invoke-WebRequest -Uri "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-format.exe" -OutFile bin\clang-format.exe
 call powershell Invoke-WebRequest -Uri "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-tidy.exe" -OutFile bin\clang-tidy.exe
 
+GOTO SetPath
+
 :CheckVersion
 
 clang-format --version | findstr 3.8 > NUL

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -90,7 +90,7 @@ namespace ManagedCodeGen
 
                 foreach (var line in lines)
                 {
-                    Regex pattern = new Regex(@"OS Name:([\sA-Za-z0-9\.-]*)$");
+                    Regex pattern = new Regex(@"OS Platform:([\sA-Za-z0-9\.-]*)$");
                     Match match = pattern.Match(line);
                     if (match.Success)
                     {
@@ -98,14 +98,19 @@ namespace ManagedCodeGen
                         {
                             _os = "Windows_NT";
                         }
-                        else if (match.Groups[1].Value.Trim() == "Mac OS X")
+                        else if (match.Groups[1].Value.Trim() == "Darwin")
                         {
                             _os = "OSX";
                         }
+                        else if (match.Groups[1].Value.Trim() == "Linux")
+                        {
+                            // Assuming anything other than Windows or OSX is a Linux flavor
+                            _os = "Linux";
+                        }
                         else
                         {
-                            _os = match.Groups[1].Value.Trim();
-
+                            Console.WriteLine("Unknown operating system. Please specify with --os");
+                            Environment.Exit(-1);
                         }
                     }
                 }


### PR DESCRIPTION
I assumed that coreclr built into the name of the operating system on
various flavors of Linux, but it turns out they are built into
Linux.<arch>.<build>. This change fixes SetPlatform to set the OS as
Linux if the OS reported by dotnet --info is not Windows or OSX.

Additionally, in bootstrap, we were trying to get the exes which do
not exist for Linux platforms (they do not have extensions). This
change fixes the wget, and makes the files executable. It also only
checks the version if the tools were already on the path.