### PR TITLE
Add more robust platform detection and checking of defaults

### DIFF
--- a/src/cijobs/cijobs.cs
+++ b/src/cijobs/cijobs.cs
@@ -382,7 +382,7 @@ namespace ManagedCodeGen
 
             public async Task<BuildInfo> GetJobBuildInfo(string repoName, string branchName, string jobName, int number)
             {
-                string buildString = String.Format("{0}/{1}/{2}", "job/{0}/job/{1}/job/{2}/{3}",
+                string buildString = String.Format("job/{0}/job/{1}/job/{2}/{3}",
                    repoName, branchName, jobName, number);
                 string buildMessage = String.Format("{0}/{1}", buildString,
                    "api/json?&tree=actions[lastBuiltRevision[SHA1]],artifacts[fileName,relativePath],result");


### PR DESCRIPTION
Fixes some usability bugs on Linux that showed up in daily use.

- Fix format string in cijobs that cropped up from Ian's change.
- Fix issue with installing tools on Linux where we weren't defaulting to the right string to find the product tools folder downloaded from the coreclr build.
- Check paths that are used in default base/diff so as to provide a more graceful error message.