### PR TITLE
Fix bugs in boostrap

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -47,6 +47,8 @@ clang-tidy --version
 echo Please install version 3.8.* and put the tools on the PATH to use jit-format.
 echo Tools can be found at http://llvm.org/releases/download.html#3.8.0
 
+goto :DownloadTools
+
 :SetPath
 
 popd

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #Quick and dirty bootstrap. 
 
-function validate_url(){
+function validate_url {
   if [[ `wget -S --spider $1  2>&1 | grep 'HTTP/1.1 200 OK'` ]];
   then
       return 0;
@@ -35,7 +35,7 @@ dotnet restore
 
 ./build.sh -p -f
 
-if ! which -s clang-format || ! which -s clang-tidy;
+if ! which -s clang-format || ! which -s clang-tidy || ! clang-format --version | grep -q 3.8 || ! clang-tidy --version | grep -q 3.8;
 then
 
     info=$(dotnet --info)


### PR DESCRIPTION
Bootstrap.sh calls validate_url, whose definition had parentheses. This
was not legal in the lab, so this change removes those parentheses.

Additionally, for the lab we need to install the 3.8 clang tools if they
are not yet installed. This change will download 3.8 if another version
of the tools is already installed.