### PR TITLE
Create compile_commands directory if it doesn't exist

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -405,12 +405,15 @@ namespace ManagedCodeGen
 
             if (config.DoClangTidy)
             {
-                string[] newCompileCommandsPath = { config.CoreCLRRoot, "bin", "obj", config.OS + "." + config.Arch + "." + config.Build, "compile_commands_full.json" };
+                string[] newCompileCommandsDirPath = { config.CoreCLRRoot, "bin", "obj", config.OS + "." + config.Arch + "." + config.Build };
                 string compileCommands = config.CompileCommands;
-                string newCompileCommands = Path.Combine(newCompileCommandsPath);
+                string newCompileCommandsDir = Path.Combine(newCompileCommandsDirPath);
+                string newCompileCommands = Path.Combine(newCompileCommandsDir, "compile_commands_full.json");
 
                 if (config.RewriteCompileCommands)
                 {
+                    // Create the compile_commands directory. If it already exists, CreateDirectory will do nothing.
+                    Directory.CreateDirectory(newCompileCommandsDir);
                     // Move original compile_commands file on non-windows
                     File.Move(config.CompileCommands, newCompileCommands);
                 }


### PR DESCRIPTION
If the obj\<os>.arch.build directory does not exist, we need to create
it or we will get a StackOverflowException. This should only happen on
Windows, as cmake will build into nmakeobj, not obj. CreateDirectory
will create the directory if it does not exist, and do nothing if the
directory already exists.