### PR TITLE
Fix validate_url for bash and move tools download to function

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,12 +1,45 @@
 #Quick and dirty bootstrap. 
 
 function validate_url {
-  if `wget -S --spider $1  2>&1 | grep 'HTTP/1.1 200 OK'`;
+  if wget -S --spider $1  2>&1 | grep -e "HTTP/1.1 200 OK";
   then
       return 0;
   else
       return 1;
   fi
+}
+
+function download_tools {
+    info=$(dotnet --info)
+    output=${info#*RID:}
+    info=${output//RID:}
+    info=${output// }
+
+    clangFormatUrl=https://clrjit.blob.core.windows.net/clang-tools/${info}/clang-format
+
+    if validate_url ${clangFormatUrl} > /dev/null;
+    then
+        echo "Downloading clang-format to bin directory"
+        # download appropriate version of clang-format
+        wget ${clangFormatUrl} -O bin/clang-format
+        chmod 751 bin/clang-format
+    fi
+
+    clangTidyUrl=https://clrjit.blob.core.windows.net/clang-tools/${info}/clang-tidy
+
+    if validate_url ${clangTidyUrl} > /dev/null;
+    then
+        echo "Downloading clang-tidy to bin directory"
+        # download appropriate version of clang-tidy
+        wget ${clangTidyUrl} -O bin/clang-tidy
+        chmod 751 bin/clang-tidy
+    fi
+
+    if [ ! -f bin/clang-format -o ! -f bin/clang-tidy ]
+    then
+        echo "Either Clang-tidy or clang-format was not installed. Please install and put them on the PATH to use jit-format."
+        echo "Tools can be found at http://llvm.org/releases/download.html#3.8.0"
+    fi
 }
 
 if ! dotnet --info; then 
@@ -35,46 +68,18 @@ dotnet restore
 
 ./build.sh -p -f
 
-if ! which -s clang-format || ! which -s clang-tidy || ! clang-format --version | grep -q 3.8 || ! clang-tidy --version | grep -q 3.8;
+if ! which clang-format || ! which clang-tidy;
 then
-
-    info=$(dotnet --info)
-    info=${output//RID:}
-    info=${output// }
-
-    clangFormatUrl=https://clrjit.blob.core.windows.net/clang-tools/${info}/clang-format
-
-    if `validate_url ${clangFormatUrl} > /dev/null`;
-    then
-        echo "Downloading clang-format to bin directory"
-        # download appropriate version of clang-format
-        wget ${clangFormatUrl} -O bin/clang-format
-        chmod 751 bin/clang-format
-    fi
-
-    clangTidyUrl=https://clrjit.blob.core.windows.net/clang-tools/${info}/clang-tidy
-
-    if `validate_url ${clangTidyUrl} > /dev/null`;
-    then
-        echo "Downloading clang-tidy to bin directory"
-        # download appropriate version of clang-tidy
-        wget ${clangTidyUrl} -O bin/clang-tidy
-        chmod 751 bin/clang-tidy
-    fi
-
-    if [ ! -f bin/clang-format -o ! -f bin/clang-tidy ]
-    then
-        echo "Either Clang-tidy or clang-format was not installed. Please install and put them on the PATH to use jit-format."
-        echo "Tools can be found at http://llvm.org/releases/download.html#3.8.0"
-    fi
+    download_tools
 else
     if ! clang-format --version | grep -q 3.8 || ! clang-tidy --version | grep -q 3.8;
     then
         echo "jit-format requires clang-format and clang-tidy version 3.8.*. Currently installed: "
         clang-format --version
         clang-tidy --version
-        echo "Please install version 3.8.* and put the tools on the PATH to use jit-format."
-        echo "Tools can be found at http://llvm.org/releases/download.html#3.8.0"
+
+        echo "Installing version 3.8 of clang tools"
+        download_tools
     fi
 fi
 


### PR DESCRIPTION
The back quotes for validate_url and the grep command were wrong for the
version of bash on our linux machines. Additionally, this change moves
the tools download to a function so we can call it both if we don't have
the tools installed and if we have the wrong version installed.