### PR TITLE
Factor diff logic, add support for --crossgen flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,17 @@ Sample help commandlines:
                     [-a] [-t <arg>] [-c] [-f] [--benchmarksonly] [-v]
                     [--core_root <arg>] [--test_root <arg>]
     
-        -b, --base <arg>        The base compiler path or tag.
-        -d, --diff <arg>        The diff compiler path or tag.
-        --crossgen <arg>        The crossgen compiler exe.
+        -b, --base <arg>        The base compiler directory or tag. Will use
+                                crossgen or clrjit from this directory,
+                                depending on whether --crossgen is
+                                specified.
+        -d, --diff <arg>        The diff compiler directory or tag. Will use
+                                crossgen or clrjit from this directory,
+                                depending on whether --crossgen is
+                                specified.
+        --crossgen <arg>        The crossgen compiler exe. When this is
+                                specified, will use clrjit from the --base
+                                and --diff directories with this crossgen
         -o, --output <arg>      The output path.
         -a, --analyze           Analyze resulting base, diff dasm
                                 directories.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ building both a base and diff locally.
 Sample help commandline:
 ```
     $ jit-dasm --help
-    usage: jit-dasm [-b <arg>] [-d <arg>] [-o <arg>] [-t <arg>] [-f <arg>]
+    usage: jit-dasm [-c <arg>] [-j <arg>] [-o <arg>] [-t <arg>] [-f <arg>]
                     [--gcinfo] [-v] [-r] [-p <arg>...] [--] <assembly>...
-
-        -b, --base <arg>           The base compiler exe.
-        -d, --diff <arg>           The diff compiler exe.
+    
+        -c, --crossgen <arg>       The crossgen compiler exe.
+        -j, --jit <arg>            The full path to the jit library.
         -o, --output <arg>         The output path.
         -t, --tag <arg>            Name of root in output directory.  Allows
                                    for many sets of output.
@@ -78,18 +78,21 @@ Sample help commandlines:
 ```
 ```
     $ jit-diff diff --help
-    usage: jit-diff diff [-b <arg>] [-d <arg>] [-o <arg>] [-a] [-t <arg>]
-                    [-m] [-f] [-v] [--core_root <arg>] [--test_root <arg>]
-
-        -b, --base <arg>        The base compiler exe or tag.
-        -d, --diff <arg>        The diff compiler exe or tag.
+    usage: jit-diff diff [-b <arg>] [-d <arg>] [--crossgen <arg>] [-o <arg>]
+                    [-a] [-t <arg>] [-c] [-f] [--benchmarksonly] [-v]
+                    [--core_root <arg>] [--test_root <arg>]
+    
+        -b, --base <arg>        The base compiler path or tag.
+        -d, --diff <arg>        The diff compiler path or tag.
+        --crossgen <arg>        The crossgen compiler exe.
         -o, --output <arg>      The output path.
         -a, --analyze           Analyze resulting base, diff dasm
                                 directories.
         -t, --tag <arg>         Name of root in output directory.  Allows
                                 for many sets of output.
-        -c, --corlibonly        Disasm *corlib only
+        -c, --corlibonly        Disasm *CorLib only
         -f, --frameworksonly    Disasm frameworks only
+        --benchmarksonly        Disasm core benchmarks only
         -v, --verbose           Enable verbose output
         --core_root <arg>       Path to test CORE_ROOT.
         --test_root <arg>       Path to test tree.

--- a/doc/getstarted.md
+++ b/doc/getstarted.md
@@ -150,7 +150,7 @@ Steps:
   from the baseline CoreCLR build to <jitutils_repo>/fx (overwriting existing versions).
 * Invoke command
 ```
-$ jit-diff diff --analyze --crossgen <coreclr_repo>/bin/Product/<platform>/crossgen --base <coreclr_repo>/bin/Product/<platform>/crossgen --diff <diff_coreclr_repo>/bin/Product/<platform>/crossgen --output <output_directory> --core_root <test_root>/core_root --test_root <test_root>
+$ jit-diff diff --analyze --crossgen <coreclr_repo>/bin/Product/<platform>/crossgen --base <coreclr_repo>/bin/Product/<platform> --diff <diff_coreclr_repo>/bin/Product/<platform> --output <output_directory> --core_root <test_root>/core_root --test_root <test_root>
 ```
 * View summary output produced by jit-diff via jit-analyze.  Report returned on stdout.
 * Check output directory

--- a/doc/getstarted.md
+++ b/doc/getstarted.md
@@ -118,9 +118,11 @@ Steps:
   same repo after saving off the baseline Product directory.
 * Ensure jit-diff, jit-analyze, and jit-dasm are on the path.
 * Create an empty output directory.
+* Copy mscorlib.dll, mscorlib.ni.dll, System.Private.CoreLib.dll, and System.Private.CoreLib.ni.dll
+  from the baseline CoreCLR build to <jitutils_repo>/fx (overwriting existing versions).
 * Invoke command
 ```
-$ jit-diff diff --analyze --frameworksonly --base <base_coreclr_repo>/bin/Product/<platform>/crossgen --diff <diff_coreclr_repo>/bin/Product/<platform>/crossgen --output <output_directory> --core_root <jitutils_repo>/fx
+$ jit-diff diff --analyze --frameworksonly --crossgen <coreclr_repo>/bin/Product/<platform>/crossgen --base <coreclr_repo>/bin/Product/<platform> --diff <diff_coreclr_repo>/bin/Product/<platform> --output <output_directory> --core_root <jitutils_repo>/fx
 ```
 * View summary output produced by jit-diff via jit-analyze.  Report returned on stdout.
 * Check output directory
@@ -144,9 +146,11 @@ Steps:
   same repo after saving off the baseline Product directory.
 * Ensure jit-diff, analyze, and jit-dasm are on the path.
 * Create an empty output directory.
+* Copy mscorlib.dll, mscorlib.ni.dll, System.Private.CoreLib.dll, and System.Private.CoreLib.ni.dll
+  from the baseline CoreCLR build to <jitutils_repo>/fx (overwriting existing versions).
 * Invoke command
 ```
-$ jit-diff diff --analyze --base <coreclr_repo>/bin/Product/<platform>/crossgen --diff <diff_coreclr_repo>/bin/Product/<platform>/crossgen --output <output_directory> --core_root <test_root>/core_root --test_root <test_root>
+$ jit-diff diff --analyze --crossgen <coreclr_repo>/bin/Product/<platform>/crossgen --base <coreclr_repo>/bin/Product/<platform>/crossgen --diff <diff_coreclr_repo>/bin/Product/<platform>/crossgen --output <output_directory> --core_root <test_root>/core_root --test_root <test_root>
 ```
 * View summary output produced by jit-diff via jit-analyze.  Report returned on stdout.
 * Check output directory
@@ -376,15 +380,14 @@ contains installed tools.
 A sample [config.json](TODO) is included in the jitutils repo as an example that can be modified
 for a developers own context.  We will go through the different elements here for added detail.
 This file supplies the configuration options for both jit-diff and jit-format. The most interesting
-section of each section of the file is the `"default"` section.  Each sub element of default
-maps directly to jit-diff or jit-format option name.  Setting a default value here for any one 
-of them will cause the tools to set them to the listed value on start up and then only override 
-that value if new options are passed on the command line.  In the jit-diff section, the `"base"` 
-and `"diff"` entries are worth going into in more detail.  The `"base"` is set to
-`"checked_osx-1526"`.  Looking down in the `"tools"` section shows that the tool is installed 
-in the `tools` sub-directory of JIT_UTILS_ROOT.  Any of the so entered tools can be used in the
-default section as a value, but they can also be passed on the command line as the value for 
-`--base` or `--diff`.
+section of the file is the `"default"` section.  Each sub element of default maps directly to jit-diff
+or jit-format option name.  Setting a default value here for any one of them will cause the tools to
+set them to the listed value on start up and then only override that value if new options are passed
+on the command line.  In the jit-diff section, the `"base"` and `"diff"` entries are worth going into
+in more detail.  The `"base"` is set to `"checked_osx-1526"`.  Looking down in the `"tools"` section
+shows that the tool is installed in the `tools` sub-directory of JIT_UTILS_ROOT.  Any of the so entered
+tools can be used in the default section as a value, but they can also be passed on the command line
+as the value for `--base` or `--diff`.
 
 ```
 {

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -68,9 +68,15 @@ namespace ManagedCodeGen
                 {
                     // Diff command section.
                     syntax.DefineCommand("diff", ref _command, Commands.Diff, "Run asm diff of base/diff.");
-                    syntax.DefineOption("b|base", ref _basePath, "The base compiler path or tag.");
-                    syntax.DefineOption("d|diff", ref _diffPath, "The diff compiler path or tag.");
-                    syntax.DefineOption("crossgen", ref _crossgenExe, "The crossgen compiler exe.");
+                    syntax.DefineOption("b|base", ref _basePath, "The base compiler directory or tag." +
+                                        " Will use crossgen or clrjit from this directory, depending on" +
+                                        " whether --crossgen is specified.");
+                    syntax.DefineOption("d|diff", ref _diffPath, "The diff compiler directory or tag." +
+                                        " Will use crossgen or clrjit from this directory, depending on" +
+                                        " whether --crossgen is specified.");
+                    syntax.DefineOption("crossgen", ref _crossgenExe, "The crossgen compiler exe." +
+                                        " When this is specified, will use clrjit from the --base and" +
+                                        " --diff directories with this crossgen");
                     syntax.DefineOption("o|output", ref _outputPath, "The output path.");
                     syntax.DefineOption("a|analyze", ref _analyze, 
                         "Analyze resulting base, diff dasm directories.");

--- a/wrapper.cmd
+++ b/wrapper.cmd
@@ -1,2 +1,2 @@
 @echo off
-dotnet.exe %~pn0.dll %*
+dotnet.exe %~d0%~pn0.dll %*


### PR DESCRIPTION
This change moves all of the diff logic to jit-diff, which will invoke
jit-dasm once for each tag.

jit-dasm now takes an argument that specifies the crossgen executable to
use, and an optional jit argument that will be passed along to crossgen
via /JITPath.

jit-diff has been modified to take an additional argument that specifies
the crossgen executable to use. With this argument, jit-diff will use
clrjit from the the --base and --diff arguments (which are now
directories instead of the full crossgen path) with the specified
crossgen. This should prevent changes to
System.Private.CoreLib.dll (which must match the crossgen version) from
manifesting as jit diffs.