### PR TITLE
Don't print message about missing JIT_UTILS_ROOT

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -298,10 +298,8 @@ namespace ManagedCodeGen
                     {
                         Console.Error.WriteLine("Can't find config.json on {0}", _jitUtilsRoot);
                     }
-                }
-                else
-                {
-                    Console.WriteLine("Environment variable JIT_UTILS_ROOT not found - no configuration loaded.");
+
+                    Console.WriteLine("Environment variable JIT_UTILS_ROOT found - configuration loaded.");
                 }
             }
 


### PR DESCRIPTION
We don't want to message about missing JIT_UTILS_ROOT. Instead, we will
message when we find a JIT_UTILS_ROOT and inform the user that a
configuration was loaded.