### PR TITLE
Look for exact name of clrjit and crossgen

### DIFF
--- a/doc/getstarted.md
+++ b/doc/getstarted.md
@@ -122,7 +122,7 @@ Steps:
   from the baseline CoreCLR build to \<jitutils_repo\>/fx (overwriting existing versions).
 * Invoke command
 ```
-$ jit-diff diff --analyze --frameworksonly --crossgen <coreclr_repo>/bin/Product/<platform>/crossgen --base <coreclr_repo>/bin/Product/<platform> --diff <diff_coreclr_repo>/bin/Product/<platform> --output <output_directory> --core_root <jitutils_repo>/fx
+$ jit-diff diff --analyze --frameworksonly --crossgen <coreclr_repo>/bin/Product/<platform>/<crossgen executable> --base <coreclr_repo>/bin/Product/<platform> --diff <diff_coreclr_repo>/bin/Product/<platform> --output <output_directory> --core_root <jitutils_repo>/fx
 ```
 * View summary output produced by jit-diff via jit-analyze.  Report returned on stdout.
 * Check output directory
@@ -150,7 +150,7 @@ Steps:
   from the baseline CoreCLR build to <jitutils_repo>/fx (overwriting existing versions).
 * Invoke command
 ```
-$ jit-diff diff --analyze --crossgen <coreclr_repo>/bin/Product/<platform>/crossgen --base <coreclr_repo>/bin/Product/<platform> --diff <diff_coreclr_repo>/bin/Product/<platform> --output <output_directory> --core_root <test_root>/Tests/core_root --test_root <test_root>
+$ jit-diff diff --analyze --crossgen <coreclr_repo>/bin/Product/<platform>/<crossgen executable> --base <coreclr_repo>/bin/Product/<platform> --diff <diff_coreclr_repo>/bin/Product/<platform> --output <output_directory> --core_root <test_root>/Tests/core_root --test_root <test_root>
 ```
 * View summary output produced by jit-diff via jit-analyze.  Report returned on stdout.
 * Check output directory


### PR DESCRIPTION
This change fixes [67](https://github.com/dotnet/jitutils/issues/67) and [68](https://github.com/dotnet/jitutils/issues/68).

Instead of using pattern matching to find clrjit and crossgen, we now look for the exact names of these binaries: libclrjit.so/crossgen on linux, and clrjit.dll/crossgen.exe on windows.

The documentation update reminds the user to use the platform-specific crossgen executable name.