### PR TITLE
Don't emit error files from jit-dasm for non-managed assemblies

### DIFF
--- a/src/cijobs/project.json
+++ b/src/cijobs/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "0.0.1.3",
   "buildOptions": {
     "debugType": "portable",
     "emitEntryPoint": true
@@ -7,8 +7,8 @@
   "dependencies": {
     "Microsoft.NETCore.App": "1.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24210-10",
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
-    "System.CommandLine": "0.1.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-003121",
+    "System.CommandLine": "0.1.0-e161108-1",
     "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {

--- a/src/jit-analyze/project.json
+++ b/src/jit-analyze/project.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.0.0-*",
+  "version": "0.0.1.1",
   "buildOptions": {
     "debugType": "portable",
     "emitEntryPoint": true
   },
   "dependencies": {
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24210-10",
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
-    "System.CommandLine": "0.1.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-003121",
+    "System.CommandLine": "0.1.0-e161108-1",
     "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -504,27 +504,41 @@ namespace ManagedCodeGen
                                 result = generateCmd.Execute();
                             }
                         }
-                        
+
                         if (result.ExitCode != 0)
                         {
-                            Console.Error.WriteLine("Error running {0} on {1}", _executablePath, fullPathAssembly);
                             _errorCount++;
-
-                            // If the tool still produced a output file rename it to indicate
-                            // the error in the file system.
-                            if (File.Exists(path))
+                            
+                            if (result.ExitCode == -2146234344)
                             {
-                                // Change file to *.err.
-                                string errorPath = Path.ChangeExtension(path, ".err");
+                                Console.Error.WriteLine("{0} is not a managed assembly", fullPathAssembly);
 
-                                // If this is a rerun to the same output, overwrite with current
-                                // error output.
-                                if (File.Exists(errorPath))
+                                // Discard output if the assembly is not managed
+                                if (File.Exists(path))
                                 {
-                                    File.Delete(errorPath);
+                                    File.Delete(path);
                                 }
+                            }
+                            else
+                            {
+                                Console.Error.WriteLine("Error running {0} on {1}", _executablePath, fullPathAssembly);
 
-                                File.Move(path, errorPath);
+                                // If the tool still produced a output file rename it to indicate
+                                // the error in the file system.
+                                if (File.Exists(path))
+                                {
+                                    // Change file to *.err.
+                                    string errorPath = Path.ChangeExtension(path, ".err");
+                                    
+                                    // If this is a rerun to the same output, overwrite with current
+                                    // error output.
+                                    if (File.Exists(errorPath))
+                                    {
+                                        File.Delete(errorPath);
+                                    }
+                                    
+                                    File.Move(path, errorPath);
+                                }
                             }
                         }
                     }

--- a/src/jit-dasm/project.json
+++ b/src/jit-dasm/project.json
@@ -1,13 +1,13 @@
 ﻿{
-    "version": "1.0.0-*",
+    "version": "0.0.1.4",
     "buildOptions": {
         "debugType": "portable",
         "emitEntryPoint": true
     },
 
     "dependencies": {
-        "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
-        "System.CommandLine": "0.1.0-*"
+        "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-003121",
+        "System.CommandLine": "0.1.0-e161108-1"
     },
 
     "frameworks": {


### PR DESCRIPTION
Also fix dependency versions to be consistent between tools and add
version numbers used to publish packages for the coreclr jitdiff jobs