### PR TITLE
Make jit-format use the same version of packages as the other tools

### DIFF
--- a/src/jit-format/project.json
+++ b/src/jit-format/project.json
@@ -6,11 +6,12 @@
     },
 
     "dependencies": {
-        "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
+        "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-003121",
         "System.CommandLine": "0.1.0-*",
         "System.Runtime": "4.1.0",
         "System.Runtime.Extensions": "4.1.0-*",
-        "System.Xml.XmlDocument": "4.0.*"
+        "System.Xml.XmlDocument": "4.0.*",
+        "Newtonsoft.Json": "8.0.3"
     },
 
     "frameworks": {


### PR DESCRIPTION
Jit-format was running into issues after a change in the dependency
versions of other jitutils tools.

Because we publish all of the jitutils tools into a common directory,
the dependencies of the last package to get published will end up in
the publish directory. Eventually we should fix this behavior, but for
now modifying jit-format to use the same dependency versions as cijobs
works around the issue.

@adiaaida @russellhadley 