### PR TITLE
Use ScriptCommandResolverPolicy

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -553,6 +553,11 @@ namespace ManagedCodeGen
             }
         }
 
+        class ScriptResolverPolicyWrapper : ICommandResolverPolicy
+        {
+            public CompositeCommandResolver CreateCommandResolver() => ScriptCommandResolverPolicy.Create();
+        }
+
         public static bool DiffInText(string diffPath, string basePath)
         {
             // run get diff command to see if we have textual diffs.
@@ -568,7 +573,7 @@ namespace ManagedCodeGen
 
             try 
             {
-                diffCmd = Command.Create(@"git", commandArgs);
+                diffCmd = Command.Create(new ScriptResolverPolicyWrapper(), @"git", commandArgs);
             }
             catch (CommandUnknownException e)
             {

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -410,6 +410,11 @@ namespace ManagedCodeGen
                 this.verbose = config.DoVerboseOutput;
             }
 
+            class ScriptResolverPolicyWrapper : ICommandResolverPolicy
+            {
+                public CompositeCommandResolver CreateCommandResolver() => ScriptCommandResolverPolicy.Create();
+            }
+
             public void GenerateAsm()
             {
                 // Build a command per assembly to generate the asm output.
@@ -445,7 +450,7 @@ namespace ManagedCodeGen
 
                     try 
                     {
-                        generateCmd = Command.Create(_executablePath, commandArgs);
+                        generateCmd = Command.Create(new ScriptResolverPolicyWrapper(), _executablePath, commandArgs);
                     }
                     catch (CommandUnknownException e)
                     {

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -675,11 +675,16 @@ namespace ManagedCodeGen
             return ret;
         }
 
+        class ScriptResolverPolicyWrapper : ICommandResolverPolicy
+        {
+            public CompositeCommandResolver CreateCommandResolver() => ScriptCommandResolverPolicy.Create();
+        }
+
         public static CommandResult TryCommand(string name, IEnumerable<string> commandArgs, bool capture = false)
         {
             try 
             {
-                Command command =  Command.Create(name, commandArgs);
+                Command command =  Command.Create(new ScriptResolverPolicyWrapper(), name, commandArgs);
 
                 if (capture)
                 {


### PR DESCRIPTION
The `DefaultCommandResolverPolicy` includes a `ProjectToolsCommandResolver`
which chokes if it finds multiple project files, so e.g. running jit-diff
from the root coreclr directory currently fails.  Update all the calls to
`Command.Create` to instead use `ScriptCommandResolverPolicy` via a local
wrapper class to proxy the interface call to the static `Create` method.