### PR TITLE
Speed up jit-analyze's ExtractMethodInfo

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -247,8 +247,8 @@ namespace ManagedCodeGen
             Regex dataPattern = new Regex(@"code ([0-9]{1,}), prolog size ([0-9]{1,})");
             return File.ReadLines(filePath)
                              .Select((x, i) => new { line = x, index = i })
-                             .Where(l => l.line.StartsWith(@"; Total bytes of code")
-                                        || l.line.StartsWith(@"; Assembly listing for method"))
+                             .Where(l => l.line.StartsWith(@"; Total bytes of code", StringComparison.Ordinal)
+                                        || l.line.StartsWith(@"; Assembly listing for method", StringComparison.Ordinal))
                              .Select((x) =>
                              {
                                  var nameMatch = namePattern.Match(x.line);


### PR DESCRIPTION
`StartsWith` defaults to `StringComparison.CurrentCulture` but that is slow and we don't really need it here, quite the contrary. Use `StringComparison.Ordinal` instead, it's 2 times faster.

`ExtractFileInfo` time drops from ~4s to ~2s on my machine when the input files are in the filesystem cache.