### PR TITLE
Fix `build -f`

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -16,7 +16,6 @@ set buildType=Release
 set publish=false
 set fx=false
 
-REM REVIEW: 'platform' is never used
 for /f "usebackq tokens=1,2" %%a in (`dotnet --info`) do (
     if "%%a"=="RID:" set platform=%%b
 )
@@ -63,7 +62,11 @@ for %%p in (%projects%) do (
 )
 
 if %fx%==true (
-    dotnet publish -c %buildType% -o %fxInstallDir% .\src\packages
+    @REM Need to expicitly restore 'packages' project for host runtime in order
+    @REM for subsequent publish to be able to accept --runtime parameter to
+    @REM publish it as standalone.
+    dotnet restore --runtime %platform% .\src\packages
+    dotnet publish -c %buildType% -o %fxInstallDir% --runtime %platform% .\src\packages
     
     @REM remove package version of mscorlib* - refer to core root version for diff testing
     if exist %fxInstallDir%\mscorlib* del /q %fxInstallDir%\mscorlib*

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,11 @@ done
 # set up fx if requested.
 
 if [ "$fx" == true ]; then
-    dotnet publish -c $buildType -o $fxInstallDir ./src/packages
+    # Need to explicitly restore 'packages' project for host runtime in order
+    # for subsequent publish to be able to accept --runtime parameter to publish
+    # it as standalone.
+    dotnet restore --runtime $platform ./src/packages
+    dotnet publish -c $buildType -o $fxInstallDir --runtime $platform ./src/packages
 
     # remove package version of mscorlib* - refer to core root version for diff testing.
     rm -f $fxInstallDir/mscorlib*

--- a/src/packages/packages.csproj
+++ b/src/packages/packages.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>packages</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>packages</PackageId>
-    <RuntimeIdentifiers>win81-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;fedora.23-x64;osx.10.10-x64;osx.10.11-x64</RuntimeIdentifiers>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
   </PropertyGroup>
 


### PR DESCRIPTION
In the migration to csproj, the frameworks-populating of `build -f` was
lost, because packages.csproj can't specify standalone like project.json
could.  With csproj, an explicit --runtime argument must be passed to
dotnet restore in order to publish as a standalone.  The dotnet publish
--runtime in turn requires that the project has been restored for the
specified runtime, so add an explicit `dotnet restore --runtime` in the
build scripts when processing -f.