### PR TITLE
Update jit-diff operation order, and parallelize

### DIFF
--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -355,7 +355,7 @@ namespace ManagedCodeGen
             {
                 if (config.DoVerboseOutput)
                 {
-                    Console.WriteLine("Scaning: {0}", filePath);
+                    Console.WriteLine("Scanning: {0}", filePath);
                 }
 
                 // skip if not an assembly
@@ -446,6 +446,20 @@ namespace ManagedCodeGen
                         commandArgs.Insert(1, String.Join(" ", _platformPaths));
                     }
 
+                    string extension = Path.GetExtension(fullPathAssembly);
+                    string nativeOutput = Path.ChangeExtension(fullPathAssembly, "ni" + extension);
+
+                    if (_rootPath != null)
+                    {
+                        string assemblyNativeFileName = Path.ChangeExtension(assembly.Name, "ni" + extension);
+                        nativeOutput = Path.Combine(_rootPath, assembly.OutputPath, assemblyNativeFileName);
+
+                        PathUtility.EnsureParentDirectoryExists(nativeOutput);
+
+                        commandArgs.Insert(0, "/out");
+                        commandArgs.Insert(1, nativeOutput);
+                    }
+
                     Command generateCmd = null;
 
                     try 
@@ -495,7 +509,7 @@ namespace ManagedCodeGen
                         // Generate path to the output file
                         var assemblyFileName = Path.ChangeExtension(assembly.Name, ".dasm");
                         var path = Path.Combine(_rootPath, assembly.OutputPath, assemblyFileName);
-                        
+
                         PathUtility.EnsureParentDirectoryExists(path);
 
                         // Redirect stdout/stderr to disasm file and run command.
@@ -564,8 +578,6 @@ namespace ManagedCodeGen
                     // assemblies in the test tree, and leaving the .ni.dll around would mean that
                     // subsequent test passes would re-use that code instead of jitting with the
                     // compiler that's supposed to be tested.
-                    string extension = Path.GetExtension(fullPathAssembly);
-                    string nativeOutput = Path.ChangeExtension(fullPathAssembly, "ni" + extension);
                     if (File.Exists(nativeOutput))
                     {
                         File.Delete(nativeOutput);

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -944,9 +944,8 @@ namespace ManagedCodeGen
 
             // Returns:
             // 0 on success,
-            // -1 on configuration failure (e.g., JIT not found),
             // Otherwise, a count of the number of failures generating asm, as reported by the asm tool.
-            private int RunDasmTool(List<string> commandArgs, List<string> assemblyPaths, string tag, string clrPath)
+            private int RunDasmTool(List<string> commandArgs, List<string> assemblyPaths)
             {
                 List<string> baseArgs = null, diffArgs = null;
 
@@ -1094,20 +1093,8 @@ namespace ManagedCodeGen
                     }
                 }
 
-                int baseStatus = 0;
-                int diffStatus = 0;
-
                 DiffTool diffTool = new DiffTool(config);
-
-                if (config.HasBasePath)
-                {
-                    baseStatus = diffTool.RunDasmTool(commandArgs, assemblyArgs, "base", config.BasePath);
-                }
-
-                if (config.HasDiffPath)
-                {
-                    diffStatus = diffTool.RunDasmTool(commandArgs, assemblyArgs, "diff", config.DiffPath);
-                }
+                int dasmFailures = diffTool.RunDasmTool(commandArgs, assemblyArgs);
 
                 // Analyze completed run.
 
@@ -1130,28 +1117,10 @@ namespace ManagedCodeGen
                 // Report any failures to generate asm at the very end (again). This is so
                 // this information doesn't get buried in previous output.
 
-                if ((baseStatus != 0) || (diffStatus != 0))
+                if (dasmFailures != 0)
                 {
                     Console.Error.WriteLine("");
-                    Console.Error.WriteLine("Warning: failures detected generating asm");
-
-                    if (baseStatus == -1)
-                    {
-                        Console.Error.WriteLine("    Baseline failed to generate asm");
-                    }
-                    else if (baseStatus > 0)
-                    {
-                        Console.Error.WriteLine("    Baseline failures: {0}", baseStatus);
-                    }
-
-                    if (diffStatus == -1)
-                    {
-                        Console.Error.WriteLine("    Diff failed to generate asm");
-                    }
-                    else if (diffStatus > 0)
-                    {
-                        Console.Error.WriteLine("    Diff failures: {0}", diffStatus);
-                    }
+                    Console.Error.WriteLine("Warning: {0} failures detected generating asm", dasmFailures);
 
                     return 1; // failure result
                 }


### PR DESCRIPTION
I reordered running diffs so base and diff of a single assembly are done back-to-back, so you can do diffs while the rest of the assemblies continue to be worked on.

The parallel work is in progress.

Any comments/suggestions?
