### PR TITLE
Simplify and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,186 +1,39 @@
 # Dotnet JIT code gen utilities - jitutils
 
 This repo holds a collection of utilities used by RyuJIT developers to 
-automate tasks when working on CoreCLR.  Initial utilities are around 
-producing diffs of codegen changes.
+automate tasks when working on CoreCLR.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Summary
 
-Copy down the appropriate `bootstrap.{cmd|sh}` for your platform and run it.  The script 
-will enlist in the jitutils project and perform the basics listed in the details section 
-following.
+Current tools include:
 
-### The details
+1. [Assembly diffs](doc/diffs.md): jit-diff, jit-dasm, jit-analyze.
+2. [CI jobs information](doc/cijobs.md): cijobs.
+2. [JIT source code formatting](doc/formatting.md): jit-format.
 
-To prepare the tools for use, from the root of the cloned jitutils repo, do the following: 
- 1. Download required package dependencies: `dotnet restore`
-    * NOTE: On Mac, you need to first use `ulimit -n 2048` or the `dotnet restore` will fail.
- 2. Build and publish the tools: `build.{cmd|sh} -f -p`
+## Getting started
 
-This will create the following directories in the repo root:
- 1. `bin` - contains built tools and wrapper scrips to drive them on the commandline.
- 2. `fx` - contains a set of frameworks assemblies that can be used for asm diffs.
-
-To enable tools on the commandline just add the `bin` directory to the path.
+1. Clone the jitutils repo:
 ```
-set jitutils=<path to root of jitutils clone>
-set PATH=%PATH%;%jitutils%\bin
+    git clone https://github.com/jitutils
 ```
 
-For a more complete introduction look at the [getting started guide](doc/getstarted.md).
+2. Install the .NET Core SDK (including the dotnet command-line interface, or CLI) from [here](https://dot.net).
 
-## jit-dasm
-
-This is a general tool to produce diffs for compiled MSIL assemblies.  The 
-tool relies on a base and diff crossgen.exe as inputs, either by using a
-prebuilt base from the CI builds and a local experimental build, or 
-building both a base and diff locally.
-
-Sample help commandline:
+3. Build the tools:
 ```
-    $ jit-dasm --help
-    usage: jit-dasm [-c <arg>] [-j <arg>] [-o <arg>] [-t <arg>] [-f <arg>]
-                    [--gcinfo] [-v] [-r] [-p <arg>...] [--] <assembly>...
-    
-        -c, --crossgen <arg>       The crossgen compiler exe.
-        -j, --jit <arg>            The full path to the jit library.
-        -o, --output <arg>         The output path.
-        -t, --tag <arg>            Name of root in output directory.  Allows
-                                   for many sets of output.
-        -f, --file <arg>           Name of file to take list of assemblies
-                                   from. Both a file and assembly list can
-                                   be used.
-        --gcinfo                   Add GC info to the disasm output.
-        -v, --verbose              Enable verbose output.
-        -r, --recursive            Scan directories recursively.
-        -p, --platform <arg>...    Path to platform assemblies
-        <assembly>...              The list of assemblies or directories to
-                                   scan for assemblies.
+    cd jitutils
+    bootstrap.cmd
+```
+(on non-Windows, run bootstrap.sh. NOTE: On Mac, you need to first use `ulimit -n 2048` or the `dotnet restore` part of the build will fail.)
+
+4. Optionally, add the built tools directory to your path, e.g.:
+```
+    set PATH=%PATH%;<root>\jitutils\bin
 ```
 
-## jit-diff
-
-jit-diff is a tool specifically targeting CoreCLR.  It has a prebaked list of interesting
-assemblies to use for generating assembly diffs and understands enough of the structure
-to make it more streamlined.  jit-diff uses jit-dasm under the covers to produce the diffs so 
-for other projects a new utility could be produced that works in a similar way.
-
-Sample help commandlines:
-```
-    $ jit-diff --help
-    usage: jit-diff <command> [<args>]
-
-        diff       Run asm diff of base/diff.
-        list       List defaults and available tools asmdiff.json.
-        install    Install tool in config.
-```
-```
-    $ jit-diff diff --help
-    usage: jit-diff diff [-b <arg>] [-d <arg>] [--crossgen <arg>] [-o <arg>]
-                    [-a] [-t <arg>] [-c] [-f] [--benchmarksonly] [-v]
-                    [--core_root <arg>] [--test_root <arg>]
-    
-        -b, --base <arg>        The base compiler directory or tag. Will use
-                                crossgen or clrjit from this directory,
-                                depending on whether --crossgen is
-                                specified.
-        -d, --diff <arg>        The diff compiler directory or tag. Will use
-                                crossgen or clrjit from this directory,
-                                depending on whether --crossgen is
-                                specified.
-        --crossgen <arg>        The crossgen compiler exe. When this is
-                                specified, will use clrjit from the --base
-                                and --diff directories with this crossgen
-        -o, --output <arg>      The output path.
-        -a, --analyze           Analyze resulting base, diff dasm
-                                directories.
-        -t, --tag <arg>         Name of root in output directory.  Allows
-                                for many sets of output.
-        -c, --corlibonly        Disasm *CorLib only
-        -f, --frameworksonly    Disasm frameworks only
-        --benchmarksonly        Disasm core benchmarks only
-        -v, --verbose           Enable verbose output
-        --core_root <arg>       Path to test CORE_ROOT.
-        --test_root <arg>       Path to test tree.
-```
-
-## jit-analyze
-
-The jit-analyze tool understand the format of the *.dasm files in a diff and can extract
-this data to produce a summary and/or dump the info to a unified data file (CSV, JSON)
-The common usage of the tool is to extract interesting diffs, if any, from a diff run as
-part of the development progresses.
-
-Sample help commandline:
-```
-    $ jit-analyze --help
-    usage: jit-analyze [-b <arg>] [-d <arg>] [-r] [-c <arg>] [-w]
-                    [--reconcile] [--json <arg>] [--tsv <arg>]
-
-        -b, --base <arg>    Base file or directory.
-        -d, --diff <arg>    Diff file or directory.
-        -r, --recursive     Search directories recursively.
-        -c, --count <arg>   Count of files and methods (at most) to output
-                            in the summary. (count) improvements and
-                            (count) regressions of each will be included.
-                            (default 5)
-        -w, --warn           Generate warning output for files/methods that
-                            only exists in one dataset or the other (only
-                            in base or only in diff).
-        --reconcile         If there are methods that exist only in base or
-                            diff, create zero-sized counterparts in diff,
-                            and vice-versa. Update size deltas accordingly.
-        --json <arg>        Dump analysis data to specified file in JSON
-                            format.
-        --tsv <arg>         Dump analysis data to specified file in
-                            tab-separated format.
-```
-
-## jit-format
-
-The jit-format tool runs clang-format and clang-tidy over all jit source, or specific files
-if they are specified. It can either tell the user that code needs to be reformatted or it
-can fix the source itself.
-
-Sample help commandline
-```
-    $ jit-format --help
-    usage: jit-format [-a <arg>] [-o <arg>] [-b <arg>] [-c <arg>]
-                      [--compile-commands <arg>] [-v] [--untidy]
-                      [--noformat] [-f] [-i] [--projects <arg>...] [--]
-                      <filenames>...
-
-        -a, --arch <arg>            The architecture of the build (options:
-                                    x64, x86)
-        -o, --os <arg>              The operating system of the build
-                                    (options: Windows, OSX, Ubuntu, Fedora,
-                                    etc.)
-        -b, --build <arg>           The build type of the build (options:
-                                    Release, Checked, Debug)
-        -c, --coreclr <arg>         Full path to base coreclr directory
-        --compile-commands <arg>    Full path to compile_commands.json
-        -v, --verbose               Enable verbose output.
-        --untidy                    Do not run clang-tidy
-        --noformat                  Do not run clang-format
-        -f, --fix                   Fix formatting errors discovered by
-                                    clang-format and clang-tidy.
-        -i, --ignore-errors         Ignore clang-tidy errors
-        --projects <arg>...         List of build projects clang-tidy should
-                                    consider (e.g. dll, standalone,
-                                    protojit, etc.). Default: dll
-        <filenames>...              Optional list of files that should be
-                                    formatted.
-```
-
-## packages
-
-This is a skeleton project that exists to pull down a predictable set of framework 
-assemblies and publish them in the root in the subdirectory './fx'.  Today this is 
-set to the RC2 version of the NetCoreApp1.0 frameworks.  When this package is installed 
-via the `build.{cmd|sh}` script this set can be used on any supported platform for 
-diffing.  Note: The RC2 mscorlib.dll is removed, as this assembly should be updated from 
-the selected base runtime that is under test for consistency. To add particular packages 
-to the set you diff, add their dependencies to the project.json in this project and 
-they will be pulled in and published in the standalone directory './fx'.
+For more complete instructions, read the [getting started guide](doc/getstarted.md).

--- a/doc/cijobs.md
+++ b/doc/cijobs.md
@@ -10,7 +10,7 @@ baseline JIT, for example.
 
 cijobs has two commands: (1) list, and (2) copy.
 
-Sample help command line:
+cijobs help message:
 ```
     $ cijobs --help
     usage: cijobs <command> [<args>]
@@ -23,7 +23,7 @@ Sample help command line:
                 ContentPath(p) parameter
 ```
 
-The "list" command has the following command line:
+The "cijobs list" command has the following help message:
 ```
     $ cijobs list --help
     usage: cijobs list [-j <arg>] [-b <arg>] [-r <arg>] [-m <arg>]
@@ -40,7 +40,7 @@ The "list" command has the following command line:
         -a, --artifacts          List job artifacts on server.
 ```
 
-The "copy" command has the following command line:
+The "cijobs copy" command has the following help message:
 ```
     usage: cijobs copy [-j <arg>] [-n <arg>] [-l] [-c <arg>] [-b <arg>]
                   [-r <arg>] [-o <arg>] [-u] [-p <arg>]

--- a/doc/cijobs.md
+++ b/doc/cijobs.md
@@ -1,0 +1,60 @@
+# CI jobs information
+
+The .NET team maintains a "continuous integration" (CI) system for testing .NET, in particular,
+for testing each source code change submitted for consideration. The "cijobs" command-line tool
+allows for querying the CI for per-job information, and for downloading archived per-job artifacts.
+These artifacts can be used for generating assembly code output, instead of building your own
+baseline JIT, for example.
+
+## cijobs
+
+cijobs has two commands: (1) list, and (2) copy.
+
+Sample help command line:
+```
+    $ cijobs --help
+    usage: cijobs <command> [<args>]
+
+        list    List jobs on dotnet-ci.cloudapp.net for the repo.
+        copy    Copies job artifacts from dotnet-ci.cloudapp.net. This
+                command copies a zip of artifacts from a repo (defaulted to
+                dotnet_coreclr). The default location of the zips is the
+                Product sub-directory, though that can be changed using the
+                ContentPath(p) parameter
+```
+
+The "list" command has the following command line:
+```
+    $ cijobs list --help
+    usage: cijobs list [-j <arg>] [-b <arg>] [-r <arg>] [-m <arg>]
+                  [-n <arg>] [-l] [-c <arg>] [-a]
+
+        -j, --job <arg>          Name of the job.
+        -b, --branch <arg>       Name of the branch (default is master).
+        -r, --repo <arg>         Name of the repo (e.g. dotnet_corefx or
+                                 dotnet_coreclr). Default is dotnet_coreclr
+        -m, --match <arg>        Regex pattern used to select jobs output.
+        -n, --number <arg>       Job number.
+        -l, --last_successful    List last successful build.
+        -c, --commit <arg>       List build at this commit.
+        -a, --artifacts          List job artifacts on server.
+```
+
+The "copy" command has the following command line:
+```
+    usage: cijobs copy [-j <arg>] [-n <arg>] [-l] [-c <arg>] [-b <arg>]
+                  [-r <arg>] [-o <arg>] [-u] [-p <arg>]
+
+        -j, --job <arg>            Name of the job.
+        -n, --number <arg>         Job number.
+        -l, --last_successful      Copy last successful build.
+        -c, --commit <arg>         Copy this commit.
+        -b, --branch <arg>         Name of the branch (default is master).
+        -r, --repo <arg>           Name of the repo (e.g. dotnet_corefx or
+                                   dotnet_coreclr). Default is
+                                   dotnet_coreclr
+        -o, --output <arg>         Output path.
+        -u, --unzip                Unzip copied artifacts
+        -p, --ContentPath <arg>    Relative product zip path. Default is
+                                   artifact/bin/Product/*zip*/Product.zip
+```

--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -1,0 +1,163 @@
+# Assembly diffs
+
+A useful technique when developing the JIT is generating assembly code output with a
+baseline compiler as well as with a compiler that has changes -- the "diff compiler"
+-- and examining the generated code differences between the two. The tools here
+automate that process.
+
+## jit-diff
+
+jit-diff is a tool used to generate asm diffs, specifically targeting CoreCLR.
+It has a prebaked list of interesting assemblies to use for generating assembly
+diffs and understands enough of the structure of CoreCLR and the dotnet/coreclr
+repro to make assembly diff generation streamlined.
+
+jit-diff uses the jit-dasm tool to produce the generated assembly files.
+
+jit-diff has three top-level commands, as shown by the "help":
+```
+    $ jit-diff --help
+    usage: jit-diff <command> [<args>]
+
+        diff       Run asm diff of base/diff.
+        list       List defaults and available tools config.json.
+        install    Install tool in config.
+```
+
+The "diff" command has the following help:
+```
+    $ jit-diff diff --help
+    usage: jit-diff diff [-b <arg>] [-d <arg>] [--crossgen <arg>] [-o <arg>]
+                    [-a] [-s] [-t <arg>] [-c] [-f] [--benchmarksonly] [-v]
+                    [--core_root <arg>] [--test_root <arg>]
+
+        -b, --base <arg>        The base compiler directory or tag. Will use
+                                crossgen or clrjit from this directory,
+                                depending on whether --crossgen is
+                                specified.
+        -d, --diff <arg>        The diff compiler directory or tag. Will use
+                                crossgen or clrjit from this directory,
+                                depending on whether --crossgen is
+                                specified.
+        --crossgen <arg>        The crossgen compiler exe. When this is
+                                specified, will use clrjit from the --base
+                                and --diff directories with this crossgen
+        -o, --output <arg>      The output path.
+        -a, --analyze           Analyze resulting base, diff dasm
+                                directories.
+        -s, --sequential        Run sequentially; don't do parallel
+                                compiles.
+        -t, --tag <arg>         Name of root in output directory.  Allows
+                                for many sets of output.
+        -c, --corlibonly        Disasm *CorLib only
+        -f, --frameworksonly    Disasm frameworks only
+        --benchmarksonly        Disasm core benchmarks only
+        -v, --verbose           Enable verbose output
+        --core_root <arg>       Path to test CORE_ROOT.
+        --test_root <arg>       Path to test tree.
+```
+
+The "list" command has this help:
+```
+    $ jit-diff diff --help
+    usage: jit-diff list [-v]
+
+        -v, --verbose    Enable verbose output
+```
+
+The "install" command has this help:
+```
+    $ jit-diff install --help
+    usage: jit-diff install [-j <arg>] [-n <arg>] [-l] [-b <arg>] [-v]
+
+        -j, --job <arg>          Name of the job.
+        -n, --number <arg>       Job number.
+        -l, --last_successful    Last successful build.
+        -b, --branch <arg>       Name of branch.
+        -v, --verbose            Enable verbose output
+```
+
+Sample usage, to create diffs:
+```
+    c:\gh\coreclr> jit-diff diff -o c:\diffs -t 5 -a -f --core_root c:\gh\coreclr\bin\tests\Windows_NT.x86.checked\Tests\Core_Root -b e:\gh\coreclr2\bin\Product\Windows_NT.x86.checked -d c:\gh\coreclr\bin\Product\Windows_NT.x86.checked
+```
+
+Explanation:
+1. `-o c:\diffs` -- specify the root directory where diffs will be placed.
+2. `-t 5` -- give the diffs a "tag". Thus, the actual root directory will be `c:\diffs\5`.
+3. `-a` -- run jit-analyze on the resultant diffs.
+4. `-f` -- generate diffs over the framework assemblies (a well-known list built in to jit-diff).
+5. `--core_root` -- specify the `CORE_ROOT` directory created by running `tests\runtest.cmd`
+   or `tests\runtest.cmd GenerateLayoutOnly` in the dotnet/coreclr repo.
+6. `-b` -- specify the directory in which a baseline crossgen.exe can be found.
+7. `-d` -- specify the directory in which a diff (experimental) crossgen.exe can be found.
+
+## jit-analyze
+
+The jit-analyze tool understands the format of the `*.dasm` files in a diff and can extract
+this data to produce a summary and/or dump the info to a data file (in CSV or JSON format).
+The common usage of the tool is to extract interesting diffs, if any, from a diff run as
+part of the development progresses.
+
+This tool can be invoked automatically after generating diffs using the `-a` option to `jit-diff diff`.
+
+Sample help command line:
+```
+    $ jit-analyze --help
+    usage: jit-analyze [-b <arg>] [-d <arg>] [-r] [-c <arg>] [-w]
+                       [--json <arg>] [--tsv <arg>]
+
+        -b, --base <arg>     Base file or directory.
+        -d, --diff <arg>     Diff file or directory.
+        -r, --recursive      Search directories recursively.
+        -c, --count <arg>    Count of files and methods (at most) to output
+                             in the summary. (count) improvements and
+                             (count) regressions of each will be included.
+                             (default 5)
+        -w, --warn           Generate warning output for files/methods that
+                             only exists in one dataset or the other (only
+                             in base or only in diff).
+        --json <arg>         Dump analysis data to specified file in JSON
+                             format.
+        --tsv <arg>          Dump analysis data to specified file in
+                             tab-separated format.
+```
+
+## jit-dasm
+
+This is a general tool to produce assembly output for compiled MSIL assemblies.
+The tool relies on crossgen.exe as input, either by using a
+prebuilt base from the CI builds, or building it locally.
+
+Sample help command line:
+```
+    $ jit-dasm --help
+    usage: jit-dasm [-c <arg>] [-j <arg>] [-o <arg>] [-t <arg>] [-f <arg>]
+                    [--gcinfo] [-v] [-r] [-p <arg>...] [--] <assembly>...
+
+        -c, --crossgen <arg>       The crossgen compiler exe.
+        -j, --jit <arg>            The full path to the jit library.
+        -o, --output <arg>         The output path.
+        -t, --tag <arg>            Name of root in output directory.  Allows
+                                   for many sets of output.
+        -f, --file <arg>           Name of file to take list of assemblies
+                                   from. Both a file and assembly list can
+                                   be used.
+        --gcinfo                   Add GC info to the disasm output.
+        -v, --verbose              Enable verbose output.
+        -r, --recursive            Scan directories recursively.
+        -p, --platform <arg>...    Path to platform assemblies
+        <assembly>...              The list of assemblies or directories to
+                                   scan for assemblies.
+```
+
+## packages
+
+This is a skeleton project that exists to pull down a predictable set of framework 
+assemblies and publish them in the root in the subdirectory './fx'.  Today this is 
+set to the NetCoreApp1.0 frameworks.  When this package is installed 
+via the `build.{cmd|sh}` script this set can be used on any supported platform for 
+diffing.  Note: The mscorlib.dll is removed, as this assembly should be updated from 
+the selected base runtime that is under test, for consistency. To add particular packages 
+to the set you diff, add their dependencies to the project.json in this project and 
+they will be pulled in and published in the standalone directory './fx'.

--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -14,7 +14,7 @@ repro to make assembly diff generation streamlined.
 
 jit-diff uses the jit-dasm tool to produce the generated assembly files.
 
-jit-diff has three top-level commands, as shown by the "help":
+jit-diff has three top-level commands, as shown by the help message:
 ```
     $ jit-diff --help
     usage: jit-diff <command> [<args>]
@@ -24,7 +24,7 @@ jit-diff has three top-level commands, as shown by the "help":
         install    Install tool in config.
 ```
 
-The "diff" command has the following help:
+The "jit-diff diff" command has the following help message:
 ```
     $ jit-diff diff --help
     usage: jit-diff diff [-b <arg>] [-d <arg>] [--crossgen <arg>] [-o <arg>]
@@ -57,7 +57,7 @@ The "diff" command has the following help:
         --test_root <arg>       Path to test tree.
 ```
 
-The "list" command has this help:
+The "jit-diff list" command has this help message:
 ```
     $ jit-diff diff --help
     usage: jit-diff list [-v]
@@ -65,7 +65,7 @@ The "list" command has this help:
         -v, --verbose    Enable verbose output
 ```
 
-The "install" command has this help:
+The "jit-diff install" command has this help message:
 ```
     $ jit-diff install --help
     usage: jit-diff install [-j <arg>] [-n <arg>] [-l] [-b <arg>] [-v]
@@ -87,10 +87,23 @@ Explanation:
 2. `-t 5` -- give the diffs a "tag". Thus, the actual root directory will be `c:\diffs\5`.
 3. `-a` -- run jit-analyze on the resultant diffs.
 4. `-f` -- generate diffs over the framework assemblies (a well-known list built in to jit-diff).
-5. `--core_root` -- specify the `CORE_ROOT` directory created by running `tests\runtest.cmd`
-   or `tests\runtest.cmd GenerateLayoutOnly` in the dotnet/coreclr repo.
+5. `--core_root` -- specify the `CORE_ROOT` directory (the "test layout").
 6. `-b` -- specify the directory in which a baseline crossgen.exe can be found.
 7. `-d` -- specify the directory in which a diff (experimental) crossgen.exe can be found.
+
+Note: you create the `CORE_ROOT` directory "layout" by running the runtest script.
+On Windows, this can be created by running
+```
+    tests\runtest.cmd
+```
+or
+```
+    tests\runtest.cmd GenerateLayoutOnly
+```
+in the dotnet/coreclr repo. On non-Windows, consult the test instructions
+[here](https://github.com/dotnet/coreclr/blob/master/Documentation/building/unix-test-instructions.md).
+Note that you can pass `--testDir=NONE` to runtest.sh to get the
+same effect as passing `GenerateLayoutOnly` to runtest.cmd on Windows.
 
 ## jit-analyze
 

--- a/doc/formatting.md
+++ b/doc/formatting.md
@@ -1,0 +1,45 @@
+# JIT source code formatting
+
+JIT source code is automatically formatted by the jit-format tool, which drives invocation of the
+clang-format and clang-tidy tools.
+
+## jit-format
+
+The jit-format tool runs clang-format and clang-tidy over all jit source, or specific files
+if they are specified. It can either tell the user that code needs to be reformatted or it
+can fix the source itself.
+
+Sample help command line
+```
+    $ jit-format --help
+    usage: jit-format [-a <arg>] [-o <arg>] [-b <arg>] [-c <arg>]
+                      [--compile-commands <arg>] [-v] [--untidy]
+                      [--noformat] [-f] [-i] [--projects <arg>...] [--]
+                      <filenames>...
+
+        -a, --arch <arg>            The architecture of the build (options:
+                                    x64, x86)
+        -o, --os <arg>              The operating system of the build
+                                    (options: Windows, OSX, Ubuntu, Fedora,
+                                    etc.)
+        -b, --build <arg>           The build type of the build (options:
+                                    Release, Checked, Debug)
+        -c, --coreclr <arg>         Full path to base coreclr directory
+        --compile-commands <arg>    Full path to compile_commands.json
+        -v, --verbose               Enable verbose output.
+        --untidy                    Do not run clang-tidy
+        --noformat                  Do not run clang-format
+        -f, --fix                   Fix formatting errors discovered by
+                                    clang-format and clang-tidy.
+        -i, --ignore-errors         Ignore clang-tidy errors
+        --projects <arg>...         List of build projects clang-tidy should
+                                    consider (e.g. dll, standalone,
+                                    protojit, etc.). Default: dll
+        <filenames>...              Optional list of files that should be
+                                    formatted.
+```
+
+Sample usage:
+```
+   c:\gh\coreclr> jit-format -c c:\gh\coreclr -f
+```


### PR DESCRIPTION
Split out README into separate files: (1) Assembly diffs
(jit-diff, jit-dasm, jit-analyze), (2) CI information (cijobs),
and (3) JIT code formatting (jit-format).