### PR TITLE
Use crossgen.exe from core_root

### DIFF
--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -132,10 +132,8 @@ The "jit-diff diff" command has this help message:
                     [--test_root <arg>] [--base_root <arg>] [--diff_root <arg>] [--arch <arg>]
                     [--build <arg>]
 
-        -b, --base [arg]      The base compiler directory or tag. Will use crossgen or clrjit from this
-                            directory, depending on whether --crossgen is specified.
-        -d, --diff [arg]      The diff compiler directory or tag. Will use crossgen or clrjit from this
-                            directory, depending on whether --crossgen is specified.
+        -b, --base [arg]      The base compiler directory or tag. Will use clrjit from this directory.
+        -d, --diff [arg]      The diff compiler directory or tag. Will use clrjit from this directory.
         --crossgen <arg>      The crossgen compiler exe. When this is specified, will use clrjit from
                             the --base and --diff directories with this crossgen.
         -o, --output <arg>    The output path.
@@ -287,7 +285,7 @@ The defaults are:
 * The default diff and baseline JIT build flavor is checked. If this isn't found, debug is tried.
   (Both baseline and diff must be the same flavor.)
 * By default, diffs are done using System.Private.CoreLib.dll. (That is, `--corelib` is the default.)
-* By default, a release build is used for `--core_root`, `--crossgen`, and `--test_root`. If not available,
+* By default, a release build is used for `--core_root` and `--test_root`. If not available,
   it falls back to checked or debug (but gives a warning that release is preferred).
 
 To instead do diffs over the framework assemblies (not just System.Private.CoreLib.dll), using an x86

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -110,20 +110,10 @@ namespace ManagedCodeGen
                 if (m_config.HasCrossgenExe)
                 {
                     dasmArgs.Add(m_config.CrossgenExe);
-
-                    var jitPath = Path.Combine(clrPath, GetJitLibraryName(m_config.PlatformMoniker));
-                    if (!File.Exists(jitPath))
-                    {
-                        Console.Error.WriteLine("clrjit not found at {0}", jitPath);
-                        return null;
-                    }
-
-                    dasmArgs.Add("--jit");
-                    dasmArgs.Add(jitPath);
                 }
                 else
                 {
-                    var crossgenPath = Path.Combine(clrPath, GetCrossgenExecutableName(m_config.PlatformMoniker));
+                    var crossgenPath = Path.Combine(m_config.CoreRoot, GetCrossgenExecutableName(m_config.PlatformMoniker));
                     if (!File.Exists(crossgenPath))
                     {
                         Console.Error.WriteLine("crossgen not found at {0}", crossgenPath);
@@ -132,6 +122,16 @@ namespace ManagedCodeGen
 
                     dasmArgs.Add(crossgenPath);
                 }
+
+                var jitPath = Path.Combine(clrPath, GetJitLibraryName(m_config.PlatformMoniker));
+                if (!File.Exists(jitPath))
+                {
+                    Console.Error.WriteLine("clrjit not found at {0}", jitPath);
+                    return null;
+                }
+
+                dasmArgs.Add("--jit");
+                dasmArgs.Add(jitPath);
 
                 return dasmArgs;
             }

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -141,11 +141,9 @@ namespace ManagedCodeGen
                     // Diff command section.
                     syntax.DefineCommand("diff", ref _command, Commands.Diff, "Run asm diff.");
                     var baseOption = syntax.DefineOption("b|base", ref _basePath, false,
-                        "The base compiler directory or tag. Will use crossgen or clrjit from this directory, " +
-                        "depending on whether --crossgen is specified.");
+                        "The base compiler directory or tag. Will use crossgen or clrjit from this directory.");
                     var diffOption = syntax.DefineOption("d|diff", ref _diffPath, false,
-                        "The diff compiler directory or tag. Will use crossgen or clrjit from this directory, " +
-                        "depending on whether --crossgen is specified.");
+                        "The diff compiler directory or tag. Will use crossgen or clrjit from this directory.");
                     syntax.DefineOption("crossgen", ref _crossgenExe,
                         "The crossgen compiler exe. When this is specified, will use clrjit from the --base and " +
                         "--diff directories with this crossgen.");
@@ -279,8 +277,8 @@ namespace ManagedCodeGen
                 bool needCoreRoot = (_platformPath == null);                            // We need to find --core_root
 
                 // It's not clear we should find a default for crossgen: in the current code, if crossgen is specified,
-                // then we always use that. If not specified, we find crossgen in either the base path or diff path,
-                // depending on what we are generating. That seems appropriate to continue, without this default.
+                // then we always use that. If not specified, we find crossgen in core_root. That seems appropriate to
+                // continue, without this default.
                 // bool needCrossgen = (_crossgenExe == null);                             // We need to find --crossgen
                 bool needCrossgen = false;
 


### PR DESCRIPTION
When --crossgen is not explicitly passed, pull it from --core_root rather
than --base or --diff; --crossgen and --core_root need to agree in build
flavor, but --base and --diff do not need to agree with them, so the
defaults of release --core_root and checked --base/--diff result in an
error otherwise.  This also helps ensure that crossgen.exe runs on the
corelib right next to it.