### PR TITLE
Separate base/diff/exception dasm error counts

### DIFF
--- a/src/jit-diff/jit-diff.csproj
+++ b/src/jit-diff/jit-diff.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This gives a quick indication of whether diffs failed more with one jit
than the other.