### PR TITLE
Support netcoreapp2.0

### DIFF
--- a/src/cijobs/cijobs.csproj
+++ b/src/cijobs/cijobs.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/jit-analyze/jit-analyze.csproj
+++ b/src/jit-analyze/jit-analyze.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/jit-dasm/jit-dasm.csproj
+++ b/src/jit-dasm/jit-dasm.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/jit-diff/jit-diff.csproj
+++ b/src/jit-diff/jit-diff.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -575,7 +575,7 @@ namespace ManagedCodeGen
 
             // write commands back to a file.
             string newCompileCommandsFileName = Path.Combine(Path.GetDirectoryName(compileCommandFile), "compile_commands.json");
-            string json = JsonConvert.SerializeObject(newCommands.ToArray(), Formatting.Indented);
+            string json = JsonConvert.SerializeObject(newCommands.ToArray(), Newtonsoft.Json.Formatting.Indented);
             System.IO.File.WriteAllText(newCompileCommandsFileName, json);
 
             return newCompileCommandsFileName;

--- a/src/jit-format/jit-format.csproj
+++ b/src/jit-format/jit-format.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/packages/packages.csproj
+++ b/src/packages/packages.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Adds a `<TargetFrameworks>` element to each project that includes
netcoreapp2.0 as a target. This is useful because it makes it possible
to build and run jitutils with a 2.0 install of the cli, which doesn't
come with a 1.0 runtime.

For now, the default target is still netcoreapp1.0, to prevent
breaking ci jobs that run jitutils with a 1.0 runtime.