### PR TITLE
Target netcoreapp2.0 by default

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -60,7 +60,7 @@ set projects=jit-diff jit-dasm jit-analyze jit-format cijobs
 REM Build each project
 for %%p in (%projects%) do (
     if %publish%==true (
-        dotnet publish -c %buildType% -t %tfm% -o %appInstallDir% .\src\%%p
+        dotnet publish -c %buildType% -f %tfm% -o %appInstallDir% .\src\%%p
         copy .\wrapper.bat %appInstallDir%\%%p.bat
     ) else (
         dotnet build -c %buildType% -f %tfm% .\src\%%p

--- a/build.cmd
+++ b/build.cmd
@@ -89,6 +89,6 @@ echo      -b ^<BUILD TYPE^> : Build type, can be Debug or Release.
 echo      -h                : Show this message.
 echo      -f                : Publish default framework directory in ^<script_root^>\fx.
 echo      -p                : Publish utilities.
-echo      -t ^<TARGET^>     : Target framework. Default is netcoreapp2.0."
+echo      -t ^<TARGET^>     : Target framework. Default is netcoreapp2.0.
 echo. 
 exit /b 1

--- a/build.cmd
+++ b/build.cmd
@@ -85,10 +85,10 @@ exit /b 0
 echo.
 echo  build.cmd [-b ^<BUILD TYPE^>] [-f] [-h] [-p] [-t ^<TARGET^>]
 echo.
-echo      -b ^<BUILD TYPE^> : Build type, can be Debug or Release.
+echo      -b ^<BUILD TYPE^>   : Build type, can be Debug or Release.
 echo      -h                : Show this message.
 echo      -f                : Publish default framework directory in ^<script_root^>\fx.
 echo      -p                : Publish utilities.
-echo      -t ^<TARGET^>     : Target framework. Default is netcoreapp2.0.
+echo      -t ^<TARGET^>       : Target framework. Default is netcoreapp2.0.
 echo. 
 exit /b 1

--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -52,12 +52,13 @@ that can be used for generating asm diffs, add '-f'.
 ```
  $ ./build.sh -h
 
-build.sh [-b <BUILD TYPE>] [-f] [-h] [-p]
+build.sh [-b <BUILD TYPE>] [-f] [-h] [-p] [-t <TARGET>]
 
     -b <BUILD TYPE> : Build type, can be Debug or Release.
     -h              : Show this message.
     -f              : Install default framework directory in <script_root>/fx.
     -p              : Publish utilities.
+    -t <TARGET>     : Target framework. Default is netcoreapp2.0.
 ```
 
 ## 50,000 foot view

--- a/src/cijobs/cijobs.csproj
+++ b/src/cijobs/cijobs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/jit-analyze/jit-analyze.csproj
+++ b/src/jit-analyze/jit-analyze.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/jit-dasm/jit-dasm.csproj
+++ b/src/jit-dasm/jit-dasm.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/jit-diff/jit-diff.csproj
+++ b/src/jit-diff/jit-diff.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/jit-format/jit-format.csproj
+++ b/src/jit-format/jit-format.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/packages/packages.csproj
+++ b/src/packages/packages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Since a few people have hit problems when trying to use jitutils with a 2.0 dotnet install, I think it's time to address https://github.com/dotnet/jitutils/issues/116.

With this change, you'll need to install the 2.0 dotnet SDK to build jitutils.

@adiaaida, I think at some point the jit-format jobs were building jitutils using some specific version of the SDK. This might require the format jobs to be updated if they still do that.

/cc @sandreenko 
