### PR TITLE
Show when number of methods differs in base/diff

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -422,7 +422,7 @@ namespace ManagedCodeGen
                 {
                     Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
 
-                    if (method.baseCount == method.diffCount)
+                    if ((method.baseCount == method.diffCount) && (method.baseCount > 0))
                     {
                         Console.Write(" ({0} methods)", method.baseCount);
                     }
@@ -431,10 +431,6 @@ namespace ManagedCodeGen
                         Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
                     }
 
-                    if (method.baseBytes == 0)
-                    {
-                        Console.Write(" only in diff");
-                    }
                     Console.WriteLine();
                 }
             }
@@ -447,7 +443,7 @@ namespace ManagedCodeGen
                 {
                     Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
 
-                    if (method.baseCount == method.diffCount)
+                    if ((method.baseCount == method.diffCount) && (method.baseCount > 0))
                     {
                         Console.Write(" ({0} methods)", method.baseCount);
                     }
@@ -456,10 +452,6 @@ namespace ManagedCodeGen
                         Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
                     }
 
-                    if (method.diffBytes == 0)
-                    {
-                        Console.Write(" only in base");
-                    }
                     Console.WriteLine();
                 }
             }

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -28,7 +28,7 @@ namespace ManagedCodeGen
             private int _count = 5;
             private string _json;
             private string _tsv;
-            private bool _reconcile = true;
+            private bool _noreconcile = false;
 
             public Config(string[] args)
             {
@@ -44,6 +44,8 @@ namespace ManagedCodeGen
                     syntax.DefineOption("w|warn", ref _warn,
                         "Generate warning output for files/methods that only "
                       + "exists in one dataset or the other (only in base or only in diff).");
+                    syntax.DefineOption("noreconcile", ref _noreconcile,
+                        "Do not reconcile unique methods in base/diff");
                     syntax.DefineOption("json", ref _json,
                         "Dump analysis data to specified file in JSON format.");
                     syntax.DefineOption("tsv", ref _tsv,
@@ -77,7 +79,7 @@ namespace ManagedCodeGen
             public string JsonFileName { get { return _json; } }
             public bool DoGenerateJson { get { return _json != null; } }
             public bool DoGenerateTSV { get { return _tsv != null; } }
-            public bool Reconcile { get { return _reconcile; } }
+            public bool Reconcile { get { return !_noreconcile; } }
         }
 
         public class FileInfo
@@ -396,7 +398,10 @@ namespace ManagedCodeGen
                                             path = fd.path,
                                             name = md.name,
                                             deltaBytes = md.deltaBytes,
-                                            count = md.baseOffsets != null ? md.baseOffsets.Count() : 1
+                                            baseBytes = md.baseBytes,
+                                            diffBytes = md.diffBytes,
+                                            baseCount = md.baseOffsets == null ? 0 : md.baseOffsets.Count(),
+                                            diffCount = md.diffOffsets == null ? 0 : md.diffOffsets.Count()
                                         }).ToList();
             var sortedMethodImprovements = methodDeltaList
                                             .Where(x => x.deltaBytes < 0)
@@ -416,9 +421,19 @@ namespace ManagedCodeGen
                 foreach (var method in sortedMethodRegressions.GetRange(0, Math.Min(methodRegressionCount, requestedCount)))
                 {
                     Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
-                    if (method.count > 1)
+
+                    if (method.baseCount == method.diffCount)
                     {
-                        Console.Write(" ({0} methods)", method.count);
+                        Console.Write(" ({0} methods)", method.baseCount);
+                    }
+                    else
+                    {
+                        Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
+                    }
+
+                    if (method.baseBytes == 0)
+                    {
+                        Console.Write(" only in diff");
                     }
                     Console.WriteLine();
                 }
@@ -431,9 +446,19 @@ namespace ManagedCodeGen
                 foreach (var method in sortedMethodImprovements.GetRange(0, Math.Min(methodImprovementCount, requestedCount)))
                 {
                     Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
-                    if (method.count > 1)
+
+                    if (method.baseCount == method.diffCount)
                     {
-                        Console.Write(" ({0} methods)", method.count);
+                        Console.Write(" ({0} methods)", method.baseCount);
+                    }
+                    else
+                    {
+                        Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
+                    }
+
+                    if (method.diffBytes == 0)
+                    {
+                        Console.Write(" only in base");
                     }
                     Console.WriteLine();
                 }

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -422,9 +422,12 @@ namespace ManagedCodeGen
                 {
                     Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
 
-                    if ((method.baseCount == method.diffCount) && (method.baseCount > 0))
+                    if (method.baseCount == method.diffCount)
                     {
-                        Console.Write(" ({0} methods)", method.baseCount);
+                        if (method.baseCount > 1)
+                        {
+                            Console.Write(" ({0} methods)", method.baseCount);
+                        }
                     }
                     else
                     {
@@ -443,9 +446,12 @@ namespace ManagedCodeGen
                 {
                     Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
 
-                    if ((method.baseCount == method.diffCount) && (method.baseCount > 0))
+                    if (method.baseCount == method.diffCount)
                     {
-                        Console.Write(" ({0} methods)", method.baseCount);
+                        if (method.baseCount > 1)
+                        {
+                            Console.Write(" ({0} methods)", method.baseCount);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
When multiple same-named methods exist in different numbers in base and
diff, make it clearer in the output. Also call out methods that are exclusive
to base or diff.

Allow analysis to skip reconciliation; this option is useful when
the larger diffs are all in unique methods and you want to focus in on the
methods that are common.