### PR TITLE
Pass /nologo to crossgen

### DIFF
--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -386,6 +386,9 @@ namespace ManagedCodeGen
                     // includes a full path to the generated .ni.dll file, which makes all base/diff
                     // asm files appear to have diffs.
                     commandArgs.Insert(0, "/silent");
+                    // Also pass /nologo to avoid spurious diffs that sometimes appear when errors
+                    // occur (sometimes the logo lines and error lines are interleaved).
+                    commandArgs.Insert(0, "/nologo");
 
                     // Set jit path if it's defined.
                     if (_jitPath != null)


### PR DESCRIPTION
Avoids spurious diffs that sometimes appear when errors occur (sometimes the logo lines and error lines are interleaved).

For example:
```diff
--- D:\Projects\diffs\dasmset_6\base\JIT\jit64\eh\FinallyExec\nonlocalgotoinatryblockinahandler\nonlocalgotoinatryblockinahandler.err	2017-11-30 21:03:30.000000000 +-0200
+++ D:\Projects\diffs\dasmset_6\diff\JIT\jit64\eh\FinallyExec\nonlocalgotoinatryblockinahandler\nonlocalgotoinatryblockinahandler.err	2017-11-30 21:03:30.000000000 +-0200
@@ -1,5 +1,5 @@
 Microsoft (R) CoreCLR Native Image Generator - Version 4.5.22220.0
-Copyright (c) Microsoft Corporation.  All rights reserved.
 Error: Could not load file or assembly 'common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified. (Exception from HRESULT: 0x80070002 (COR_E_FILENOTFOUND))
+Copyright (c) Microsoft Corporation.  All rights reserved.
 Error compiling D:\Projects\coreclr\bin\tests\Windows_NT.x64.Checked\JIT\jit64\eh\FinallyExec\nonlocalgotoinatryblockinahandler\nonlocalgotoinatryblockinahandler.exe: Could not find or load a specific file. (Exception from HRESULT: 0x80131621 (COR_E_FILELOAD))
 Error: compilation failed for "D:\Projects\coreclr\bin\tests\Windows_NT.x64.Checked\JIT\jit64\eh\FinallyExec\nonlocalgotoinatryblockinahandler\nonlocalgotoinatryblockinahandler.exe" (0x80131621)
```