### PR TITLE
PMI: rework as visitor pattern to support generic type exploration

### DIFF
--- a/src/pmi/PMI.csproj
+++ b/src/pmi/PMI.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Management" Version="4.5.0" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -602,6 +602,8 @@ class Worker
         // Only handle the very simplest cases for now
         if (genericArguments.Length > 2)
         {
+            Console.WriteLine();
+            Console.WriteLine($"Failed to instantiate {type.FullName} -- too many type parameters");
             return results;
         }
 
@@ -652,15 +654,22 @@ class Worker
                     results.Add(newType);
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                // Probably missing a constraint check
+                Console.WriteLine();
+                Console.WriteLine($"TypeInstantationException {type.FullName} - {e.Message}");
             }
 
             if (instantiationCount >= instantiationLimit)
             {
                 break;
             }
+        }
+
+        if (instantiationCount == 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Failed to instantiate {type.FullName} -- could not find valid type substitutions");
         }
 
         return results;
@@ -673,6 +682,8 @@ class Worker
     static bool AreConstraintsSatisfied(Type type, Type parameterType)
     {
         bool areConstraintsSatisfied = true;
+
+        // Check special constraints
         GenericParameterAttributes gpa = parameterType.GenericParameterAttributes;
 
         if ((gpa & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
@@ -682,7 +693,9 @@ class Worker
                 areConstraintsSatisfied = false;
             }
         }
-        else
+
+        // If all special constaints are satisfied, check type constraints
+        if (areConstraintsSatisfied)
         {
             Type[] constraints = parameterType.GetGenericParameterConstraints();
 

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -5,83 +5,236 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Numerics;
 using System.Reflection;
 
-struct MicroMethodInfo
+// This set of classes provides a way to forcibly jit a large number of methods.
+// It can be used as is or included as a component in jit measurement and testing
+// tools.
+//
+// In .Net Core, PrepareMethod should give codegen that is very similar to
+// the code one would see if the method were actually called (the same is not
+// as true in .Net Framework -- in paritcular the jit may make very different
+// inlining decisions).
+//
+// Assemblies defining generic types and generic methods require special handling.
+// Methods in generic types and generic methods can inspire the jit to create
+// numerous different method bodies depending on the type parameters used
+// for instantation.
+// 
+// The code below uses a very simple generic instantiation strategy. It currently
+// only handles one- and two-parameter generic types with simple constraints.
+
+// Base class for visiting types and methods in an assembly.
+class Visitor
 {
-    public RuntimeMethodHandle RMH;
-    public string name;
-    public bool IsAbstract;
-    public bool ContainsGenericParameters;
+    protected DateTime startTime;
+    protected string assemblyName;
+
+    public void Init(string assemblyPath)
+    {
+        assemblyName = assemblyPath;
+    }
+
+    public virtual void StartAssembly(Assembly assembly)
+    {
+        startTime = DateTime.Now;
+    }
+
+    public virtual void FinishAssembly(Assembly assembly)
+    {
+    }
+
+    public virtual void StartType(Type type)
+    {
+    }
+
+    public virtual void FinishType(Type type)
+    {
+    }
+
+    public virtual void StartMethod(Type type, MethodBase method)
+    {
+    }
+
+    public virtual bool FinishMethod(Type type, MethodBase method)
+    {
+        return true;
+    }
+
+    public TimeSpan ElapsedTime()
+    {
+        return DateTime.Now - startTime;
+    }
 }
 
-// Jit all the methods in an assembly via PrepareMethod.
-class PrepareMethodinator
+// Support for counting types and methods.
+class CounterBase : Visitor
 {
+    protected int typeCount;
+    protected int methodCount;
 
-    private static TimeSpan PrepareMethod(Type t, MicroMethodInfo mMI)
+    public override void StartAssembly(Assembly assembly)
+    {
+        base.StartAssembly(assembly);
+    }
+
+    public override void FinishType(Type type)
+    {
+        typeCount++;
+        base.FinishType(type);
+    }
+
+    public override bool FinishMethod(Type type, MethodBase method)
+    {
+        methodCount++;
+        return base.FinishMethod(type, method);
+    }
+}
+
+// Counts types and methods
+class Counter : CounterBase
+{
+    public override void StartAssembly(Assembly assembly)
+    {
+        base.StartAssembly(assembly);
+        Console.WriteLine($"Computing Count for {assemblyName}");
+    }
+
+    public override void StartType(Type type)
+    {
+        base.StartType(type);
+        Console.WriteLine($"#types: {typeCount}, #methods: {methodCount}, before type {type.FullName}");
+    }
+
+    public override void FinishAssembly(Assembly assembly)
+    {
+        base.FinishAssembly(assembly);
+        TimeSpan elapsed = ElapsedTime();
+        Console.WriteLine(
+            $"Counts {assemblyName} - #types: {typeCount}, #methods: {methodCount}, " +
+            $"elapsed time: {elapsed}, elapsed ms: {elapsed.TotalMilliseconds}");
+    }
+}
+
+// Invoke the jit on some methods
+abstract class PrepareBase : CounterBase
+{
+    protected int firstMethod;
+    protected int methodsPrepared;
+    protected DateTime startType;
+
+    public PrepareBase(int f = 0)
+    {
+        firstMethod = f;
+    }
+
+    public override void StartAssembly(Assembly assembly)
+    {
+        base.StartAssembly(assembly);
+    }
+
+    public override void FinishAssembly(Assembly assembly)
+    {
+        base.FinishAssembly(assembly);
+
+        TimeSpan elapsed = ElapsedTime();
+        Console.WriteLine(
+            $"Completed assembly {assemblyName} - #types: {typeCount}, #methods: {methodsPrepared}, " +
+            $"elapsed time: {elapsed}, elapsed ms: {elapsed.TotalMilliseconds}");
+    }
+
+    public override void StartType(Type type)
+    {
+        base.StartType(type);
+        Console.WriteLine("Start type {0}", type.FullName);
+        startType = DateTime.Now;
+    }
+
+    public override void FinishType(Type type)
+    {
+        TimeSpan elapsedType = DateTime.Now - startType;
+        Console.WriteLine("Completed type {0}, type elapsed time: {1}, elapsed ms: {2}",
+            type.FullName, elapsedType, elapsedType.TotalMilliseconds);
+
+        base.FinishType(type);
+    }
+
+    public override void StartMethod(Type type, MethodBase method)
+    {
+        base.StartMethod(type, method);
+        AttemptMethod(type, method);
+    }
+
+    public abstract void AttemptMethod(Type type, MethodBase method);
+
+    protected TimeSpan PrepareMethod(Type type, MethodBase method)
     {
         TimeSpan elapsedFunc = TimeSpan.MinValue;
+
         try
         {
             DateTime startFunc = DateTime.Now;
-            System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(mMI.RMH);
+            System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(method.MethodHandle);
             elapsedFunc = DateTime.Now - startFunc;
         }
         catch (System.EntryPointNotFoundException)
         {
             Console.WriteLine();
-            Console.WriteLine("EntryPointNotFoundException {0}::{1}", t.FullName, mMI.name);
+            Console.WriteLine("EntryPointNotFoundException {0}::{1}", type.FullName, method.Name);
         }
         catch (System.BadImageFormatException)
         {
             Console.WriteLine();
-            Console.WriteLine("BadImageFormatException {0}::{1}", t.FullName, mMI.name);
+            Console.WriteLine("BadImageFormatException {0}::{1}", type.FullName, method.Name);
         }
         catch (System.MissingMethodException)
         {
             Console.WriteLine();
-            Console.WriteLine("MissingMethodException {0}::{1}", t.FullName, mMI.name);
+            Console.WriteLine("MissingMethodException {0}::{1}", type.FullName, method.Name);
         }
         catch (System.ArgumentException e)
         {
             Console.WriteLine();
-            Console.WriteLine("ArgumentException {0}::{1} {2}", t.FullName, mMI.name, e.Message.Split(new char[] { '\r', '\n' })[0]);
+            Console.WriteLine("ArgumentException {0}::{1} {2}",
+                type.FullName, method.Name, e.Message.Split(new char[] { '\r', '\n' })[0]);
         }
         catch (System.IO.FileNotFoundException eFileNotFound)
         {
             Console.WriteLine();
-            Console.WriteLine("FileNotFoundException {0}::{1} - {2} ({3})", t.FullName, mMI.name, eFileNotFound.FileName, eFileNotFound.Message);
+            Console.WriteLine("FileNotFoundException {0}::{1} - {2} ({3})",
+                type.FullName, method.Name, eFileNotFound.FileName, eFileNotFound.Message);
         }
         catch (System.DllNotFoundException eDllNotFound)
         {
             Console.WriteLine();
-            Console.WriteLine("DllNotFoundException {0}::{1} ({2})", t.FullName, mMI.name, eDllNotFound.Message);
+            Console.WriteLine("DllNotFoundException {0}::{1} ({2})", type.FullName, method.Name, eDllNotFound.Message);
         }
         catch (System.TypeInitializationException eTypeInitialization)
         {
             Console.WriteLine();
-            Console.WriteLine("TypeInitializationException {0}::{1} - {2} ({3})", t.FullName, mMI.name, eTypeInitialization.TypeName, eTypeInitialization.Message);
+            Console.WriteLine("TypeInitializationException {0}::{1} - {2} ({3})",
+                type.FullName, method.Name, eTypeInitialization.TypeName, eTypeInitialization.Message);
         }
         catch (System.Runtime.InteropServices.MarshalDirectiveException)
         {
             Console.WriteLine();
-            Console.WriteLine("MarshalDirectiveException {0}::{1}", t.FullName, mMI.name);
+            Console.WriteLine("MarshalDirectiveException {0}::{1}", type.FullName, method.Name);
         }
         catch (System.TypeLoadException)
         {
             Console.WriteLine();
-            Console.WriteLine("TypeLoadException {0}::{1}", t.FullName, mMI.name);
+            Console.WriteLine("TypeLoadException {0}::{1}", type.FullName, method.Name);
         }
         catch (System.OverflowException)
         {
             Console.WriteLine();
-            Console.WriteLine("OverflowException {0}::{1}", t.FullName, mMI.name);
+            Console.WriteLine("OverflowException {0}::{1}", type.FullName, method.Name);
         }
         catch (System.InvalidProgramException)
         {
             Console.WriteLine();
-            Console.WriteLine("InvalidProgramException {0}::{1}", t.FullName, mMI.name);
+            Console.WriteLine("InvalidProgramException {0}::{1}", type.FullName, method.Name);
         }
         catch (Exception e)
         {
@@ -89,7 +242,152 @@ class PrepareMethodinator
             Console.WriteLine("Unknown exception");
             Console.WriteLine(e);
         }
+
         return elapsedFunc;
+    }
+
+    private void WriteAndFlushNextMethodToPrepMarker()
+    {
+        int nextMethodToPrep = (methodCount + 1);
+
+        using (var writer = new StreamWriter(File.Create("NextMethodToPrep.marker")))
+        {
+            writer.Write("{0}", nextMethodToPrep);
+        }
+    }
+}
+
+// Invoke the jit on all methods starting from an initial method.
+// By default the initial method is the first one visisted.
+class PrepareAll : PrepareBase
+{
+    string pmiFullLogFileName;
+    string pmiPartialLogFileName;
+
+    public PrepareAll(int f = 0) : base(f)
+    {
+    }
+
+    public override void StartAssembly(Assembly assembly)
+    {
+        base.StartAssembly(assembly);
+        Console.WriteLine($"Prepall for {assemblyName}");
+        pmiFullLogFileName = String.Format("{0}.pmi", Path.GetFileNameWithoutExtension(assemblyName));
+        pmiPartialLogFileName = String.Format("{0}.pmiPartial", Path.GetFileNameWithoutExtension(assemblyName));
+    }
+
+    public override void AttemptMethod(Type type, MethodBase method)
+    {
+        WriteAndFlushNextMethodToPrepMarker();
+
+        if (methodCount >= firstMethod)
+        {
+            methodsPrepared++;
+
+            if (method.IsAbstract)
+            {
+                Console.WriteLine("PREPALL type# {0} method# {1} {2}::{3} - skipping (abstract)",
+                    typeCount, methodCount, type.FullName, method.Name);
+            }
+            else if (method.ContainsGenericParameters)
+            {
+                Console.WriteLine("PREPALL type# {0} method# {1} {2}::{3} - skipping (generic parameters)",
+                    typeCount, methodCount, type.FullName, method.Name);
+            }
+            else
+            {
+                Console.Write("PREPALL type# {0} method# {1} {2}::{3}", typeCount, methodCount, type.FullName, method.Name);
+                TimeSpan elapsedFunc = PrepareMethod(type, method);
+                if (elapsedFunc != TimeSpan.MinValue)
+                {
+                    Console.WriteLine(", elapsed time: {0}, elapsed ms: {1}",
+                        elapsedFunc, elapsedFunc.TotalMilliseconds);
+                }
+            }
+        }
+    }
+
+    private void WriteAndFlushNextMethodToPrepMarker()
+    {
+        int nextMethodToPrep = (methodCount + 1);
+
+        using (var writer = new StreamWriter(File.Create("NextMethodToPrep.marker")))
+        {
+            writer.Write("{0}", nextMethodToPrep);
+        }
+    }
+}
+
+// Invoke the jit on exactly one method.
+class PrepareOne : PrepareBase
+{
+    public PrepareOne(int firstMethod) : base(firstMethod)
+    {
+    }
+
+    public override void StartAssembly(Assembly assembly)
+    {
+        base.StartAssembly(assembly);
+        Console.WriteLine($"Prepone for {assemblyName} method {firstMethod} ");
+    }
+
+    public override void AttemptMethod(Type type, MethodBase method)
+    {
+        if (methodCount >= firstMethod)
+        {
+            methodsPrepared++;
+
+            if (method.IsAbstract)
+            {
+                Console.WriteLine("PREPONE type# {0} method# {1} {2}::{3} - skipping (abstract)",
+                    typeCount, methodCount, type.FullName, method.Name);
+            }
+            else if (method.ContainsGenericParameters)
+            {
+                Console.WriteLine("PREPONE type# {0} method# {1} {2}::{3} - skipping (generic parameters)",
+                    typeCount, methodCount, type.FullName, method.Name);
+            }
+            else
+            {
+                Console.Write("PREPONE type# {0} method# {1} {2}::{3}", typeCount, methodCount, type.FullName, method.Name);
+                TimeSpan elapsedFunc = PrepareMethod(type, method);
+                if (elapsedFunc != TimeSpan.MinValue)
+                {
+                    Console.WriteLine(", elapsed time: {0}, elapsed ms: {1}",
+                        elapsedFunc, elapsedFunc.TotalMilliseconds);
+                }
+            }
+        }
+    }
+
+    public override bool FinishMethod(Type type, MethodBase method)
+    {
+        bool baseResult = base.FinishMethod(type, method);
+        return baseResult && (methodCount <= firstMethod);
+    }
+}
+
+static class GlobalMethodHolder
+{
+    public static MethodBase[] GlobalMethodInfoSet;
+
+    public static void PopulateGlobalMethodInfoSet(MethodBase[] globalMethods)
+    {
+        GlobalMethodInfoSet = globalMethods;
+    }
+}
+
+// The worker is responsible for driving the visitor through the
+// types and methods of an assembly.
+//
+// It includes the generic instantiation strategy.
+class Worker
+{
+    Visitor visitor;
+
+    public Worker(Visitor v)
+    {
+        visitor = v;
     }
 
     private static BindingFlags BindingFlagsForCollectingAllMethodsOrCtors = (
@@ -100,44 +398,48 @@ class PrepareMethodinator
         BindingFlags.Static
     );
 
-    static class GlobalMethodHolder
+    private static Assembly LoadAssembly(string assemblyPath)
     {
-        public static MicroMethodInfo[] GlobalMethodInfoSet;
+        Assembly result = null;
 
-        public static void PopulateGlobalMethodInfoSet(MethodInfo[] globalMethods)
+        // The core library needs special handling as it often is in fragile ngen format
+        if (assemblyPath.EndsWith("System.Private.CoreLib.dll") || assemblyPath.EndsWith("mscorlib.dll"))
         {
-            int index;
-            int numberOfMethods;
-
-            numberOfMethods = globalMethods.Length;
-
-            GlobalMethodInfoSet = new MicroMethodInfo[numberOfMethods];
-
-            for (index = 0; index < numberOfMethods; index++)
+            result = typeof(object).Assembly;
+        }
+        else
+        {
+            try
             {
-                GlobalMethodInfoSet[index].RMH = globalMethods[index].MethodHandle;
-                GlobalMethodInfoSet[index].name = globalMethods[index].Name;
-                GlobalMethodInfoSet[index].IsAbstract = globalMethods[index].IsAbstract;
-                GlobalMethodInfoSet[index].ContainsGenericParameters = globalMethods[index].ContainsGenericParameters;
+                result = Assembly.LoadFrom(assemblyPath);
+            }
+            catch (ArgumentException)
+            {
+                Console.WriteLine("Assembly load failure ({0}): ArgumentException", assemblyPath);
+            }
+            catch (BadImageFormatException e)
+            {
+                Console.WriteLine("Assembly load failure ({0}): BadImageFormatException (is it a managed assembly?)", assemblyPath);
+                Console.WriteLine(e);
+            }
+            catch (FileLoadException)
+            {
+                Console.WriteLine("Assembly load failure ({0}): FileLoadException", assemblyPath);
+            }
+            catch (FileNotFoundException)
+            {
+                Console.WriteLine("Assembly load failure ({0}): file not found", assemblyPath);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Console.WriteLine("Assembly load failure ({0}): UnauthorizedAccessException", assemblyPath);
             }
         }
+
+        return result;
     }
 
-    private static int GetRMHCountOnly(Type t)
-    {
-        if (Object.ReferenceEquals(t, typeof(GlobalMethodHolder)))
-        {
-            return GlobalMethodHolder.GlobalMethodInfoSet.Length;
-        }
-
-        MethodInfo[] mi = t.GetMethods(BindingFlagsForCollectingAllMethodsOrCtors);
-
-        ConstructorInfo[] ci = t.GetConstructors(BindingFlagsForCollectingAllMethodsOrCtors);
-
-        return (mi.Length + ci.Length);
-    }
-
-    private static MicroMethodInfo[] GetRMH(Type t)
+    static MethodBase[] GetMethods(Type t)
     {
         if (Object.ReferenceEquals(t, typeof(GlobalMethodHolder)))
         {
@@ -145,40 +447,274 @@ class PrepareMethodinator
         }
 
         MethodInfo[] mi = t.GetMethods(BindingFlagsForCollectingAllMethodsOrCtors);
-
         ConstructorInfo[] ci = t.GetConstructors(BindingFlagsForCollectingAllMethodsOrCtors);
-
-        MicroMethodInfo[] mMI = new MicroMethodInfo[mi.Length + ci.Length];
+        MethodBase[] mMI = new MethodBase[mi.Length + ci.Length];
 
         for (int i = 0; i < mi.Length; i++)
         {
-            mMI[i].RMH = mi[i].MethodHandle;
-            mMI[i].name = mi[i].Name;
-            mMI[i].IsAbstract = mi[i].IsAbstract;
-            mMI[i].ContainsGenericParameters = mi[i].ContainsGenericParameters;
+            mMI[i] = mi[i];
         }
 
         for (int i = 0; i < ci.Length; i++)
         {
-            mMI[i + mi.Length].RMH = ci[i].MethodHandle;
-            mMI[i + mi.Length].name = ci[i].Name;
-            mMI[i + mi.Length].IsAbstract = ci[i].IsAbstract;
-            mMI[i + mi.Length].ContainsGenericParameters = ci[i].ContainsGenericParameters;
+            mMI[i + mi.Length] = ci[i];
         }
 
         return mMI;
     }
 
-    private static void WriteAndFlushNextMethodToPrepMarker(int methodBeingPrepped)
+    private static List<Type> LoadTypes(Assembly assembly)
     {
-        int nextMethodToPrep = (methodBeingPrepped + 1);
+        List<Type> result = new List<Type>();
 
-        using (var writer = new StreamWriter(File.Create("NextMethodToPrep.marker")))
+        var globalMethods = assembly.ManifestModule.GetMethods(BindingFlagsForCollectingAllMethodsOrCtors);
+
+        if (globalMethods.Length > 0)
         {
-            writer.Write("{0}", nextMethodToPrep);
+            GlobalMethodHolder.PopulateGlobalMethodInfoSet(globalMethods);
+            result.Add(typeof(GlobalMethodHolder));
+        }
+
+        try
+        {
+            result.AddRange(assembly.GetTypes());
+            return result;
+        }
+        catch (ReflectionTypeLoadException e)
+        {
+            Console.WriteLine("ReflectionTypeLoadException {0}", assembly);
+            Exception[] ea = e.LoaderExceptions;
+            foreach (Exception e2 in ea)
+            {
+                string[] ts = e2.ToString().Split('\'');
+                string temp = ts[1];
+                ts = temp.Split(',');
+                temp = ts[0];
+                Console.WriteLine("ReflectionTypeLoadException {0} {1}", temp, assembly);
+            }
+            return null;
+        }
+        catch (FileLoadException)
+        {
+            Console.WriteLine("FileLoadException {0}", assembly);
+            return null;
+        }
+        catch (FileNotFoundException e)
+        {
+            string temp = e.ToString();
+            string[] ts = temp.Split('\'');
+            temp = ts[1];
+            Console.WriteLine("FileNotFoundException {1} {0}", temp, assembly);
+            return null;
         }
     }
 
+    public int Work(string assemblyName)
+    {
+        Assembly assembly = LoadAssembly(Path.GetFullPath(assemblyName));
+
+        if (assembly == null)
+        {
+            return 102;
+        }
+
+        List<Type> types = LoadTypes(assembly);
+
+        if (types == null)
+        {
+            return 103;
+        }
+
+        visitor.Init(assemblyName);
+        visitor.StartAssembly(assembly);
+
+        bool keepGoing = true;
+
+        foreach (Type t in types)
+        {
+            // Skip types with no jittable methods
+            if (t.IsInterface)
+            {
+                continue;
+            }
+
+            // Likewise there are no methods of interest in delegates.
+            if (t.IsSubclassOf(typeof(System.Delegate)))
+            {
+                continue;
+            }
+
+            if (t.IsGenericType)
+            {
+                List<Type> instances = GetInstances(t);
+
+                foreach (Type ti in instances)
+                {
+                    keepGoing = Work(ti);
+                    if (!keepGoing)
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                keepGoing = Work(t);
+            }
+
+            if (!keepGoing)
+            {
+                break;
+            }
+        }
+
+        visitor.FinishAssembly(assembly);
+
+        return 0;
+    }
+
+    bool Work(Type type)
+    {
+        visitor.StartType(type);
+        bool keepGoing = true;
+        foreach (MethodBase methodBase in GetMethods(type))
+        {
+            visitor.StartMethod(type, methodBase);
+            keepGoing = visitor.FinishMethod(type, methodBase);
+            if (!keepGoing)
+            {
+                break;
+            }
+        }
+
+        visitor.FinishType(type);
+
+        return keepGoing;
+    }
+
+    private List<Type> GetInstances(Type type)
+    {
+        List<Type> results = new List<Type>();
+
+        // Get the args for this generic
+        Type[] genericArguments = type.GetGenericArguments();
+
+        // Only handle the very simplest cases for now
+        if (genericArguments.Length > 2)
+        {
+            return results;
+        }
+
+        // Types we will use for instantiation attempts.
+        Type[] typesToTry = new Type[] { typeof(object), typeof(int), typeof(double), typeof(Vector<float>) };
+
+        // To keep things sane, we won't try and instantiate too many copies
+        int instantiationLimit = genericArguments.Length * typesToTry.Length;
+        int instantiationCount = 0;
+
+        foreach (Type firstType in typesToTry)
+        {
+            bool areConstraintsSatisfied = AreConstraintsSatisfied(firstType, genericArguments[0]);
+
+            Type secondType = null;
+
+            if (genericArguments.Length == 2)
+            {
+                foreach (Type secondTypeX in typesToTry)
+                {
+                    areConstraintsSatisfied &= AreConstraintsSatisfied(secondTypeX, genericArguments[1]);
+                    secondType = secondTypeX;
+                }
+            }
+
+            if (!areConstraintsSatisfied)
+            {
+                continue;
+            }
+
+            // Now try and instantiate.
+            try
+            {
+                Type newType = null;
+
+                if (genericArguments.Length == 1)
+                {
+                    newType = type.MakeGenericType(firstType);
+                }
+                else if (genericArguments.Length == 2)
+                {
+                    newType = type.MakeGenericType(firstType, secondType);
+                }
+
+                // If we can instantiate, prepare the methods.
+                if (newType != null)
+                {
+                    results.Add(newType);
+                }
+            }
+            catch (Exception)
+            {
+                // Probably missing a constraint check
+            }
+
+            if (instantiationCount >= instantiationLimit)
+            {
+                break;
+            }
+        }
+
+        return results;
+    }
+
+    // Try and identify obviously invalid type substitutions.
+    //
+    // It is ok if we miss some, as we catch the exception that will
+    // arise when instantating with an invalid type.
+    static bool AreConstraintsSatisfied(Type type, Type parameterType)
+    {
+        bool areConstraintsSatisfied = true;
+        GenericParameterAttributes gpa = parameterType.GenericParameterAttributes;
+
+        if ((gpa & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+        {
+            if (type.IsValueType)
+            {
+                areConstraintsSatisfied = false;
+            }
+        }
+        else
+        {
+            Type[] constraints = parameterType.GetGenericParameterConstraints();
+
+            foreach (Type c in constraints)
+            {
+                if (c.IsClass)
+                {
+                    // Base Type Constraint
+                    if (!type.IsSubclassOf(c)) // variance probably needs other checks
+                    {
+                        areConstraintsSatisfied = false;
+                        break;
+                    }
+                }
+                else
+                {
+                    // Interface constraint
+                    if (!type.IsInstanceOfType(c))
+                    {
+                        areConstraintsSatisfied = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return areConstraintsSatisfied;
+    }
+}
+
+class PrepareMethodinator
+{
     private static Assembly MyResolveEventHandler(object sender, ResolveEventArgs args)
     {
         string pmiPath = Environment.GetEnvironmentVariable("PMIPATH");
@@ -254,10 +790,12 @@ class PrepareMethodinator
         string assemblyName = args[1];
         int methodToPrep = -1; // For PREPONE, PREPALL. For PREPALL, this is the first method to prep.
 
+        Visitor v = null;
+
         switch (command)
         {
-            case "COUNT":
             case "DRIVEALL":
+            case "COUNT":
                 if (args.Length < 2)
                 {
                     Console.WriteLine("ERROR: too few arguments");
@@ -268,9 +806,18 @@ class PrepareMethodinator
                     Console.WriteLine("ERROR: too many arguments");
                     return Usage();
                 }
+
+                if (command == "DRIVEALL")
+                {
+                    return PMIDriver.PMIDriver.Drive(assemblyName);
+                }
+
+                v = new Counter();
                 break;
 
             case "PREPALL":
+            case "PREPONE":
+
                 if (args.Length < 3)
                 {
                     methodToPrep = 0;
@@ -280,33 +827,8 @@ class PrepareMethodinator
                     Console.WriteLine("ERROR: too many arguments");
                     return Usage();
                 }
-                break;
-
-            case "PREPONE":
-                if (args.Length < 3)
+                else
                 {
-                    Console.WriteLine("ERROR: too few arguments");
-                    return Usage();
-                }
-                else if (args.Length > 3)
-                {
-                    Console.WriteLine("ERROR: too many arguments");
-                    return Usage();
-                }
-                break;
-
-            default:
-                Console.WriteLine("ERROR: Unknown command {0}", command);
-                return Usage();
-        }
-
-        // Parse the method number.
-        if (methodToPrep == -1)
-        {
-            switch (command)
-            {
-                case "PREPALL":
-                case "PREPONE":
                     try
                     {
                         methodToPrep = Convert.ToInt32(args[2]);
@@ -316,233 +838,25 @@ class PrepareMethodinator
                         Console.WriteLine("ERROR: illegal method number");
                         return Usage();
                     }
-                    if (methodToPrep < 0)
-                    {
-                        Console.WriteLine("ERROR: method number must be greater than 0");
-                        return Usage();
-                    }
-                    break;
-            }
-        }
-
-        // Done parsing arguments. Start loading the assembly and its types.
-        if (command == "DRIVEALL")
-        {
-            return PMIDriver.PMIDriver.Drive(assemblyName);
-        }
-
-        // We want to handle specifying a "load path" where assemblies can be found.
-        // The environment variable PMIPATH is a semicolon-separated list of paths. If the
-        // Assembly can't be found by the usual mechanisms, our Assembly ResolveEventHandler
-        // will be called, and we'll probe on the PMIPATH list.
-        AppDomain currentDomain = AppDomain.CurrentDomain;
-        currentDomain.AssemblyResolve += new ResolveEventHandler(MyResolveEventHandler);
-
-        Assembly aAssem = null;
-        List<Type> aTypes = null;
-        DateTime start = DateTime.Now;
-
-        assemblyName = System.IO.Path.GetFullPath(assemblyName); // Convert it to an absolute path before calling LoadFrom
-
-        try
-        {
-            aAssem = Assembly.LoadFrom(assemblyName);
-        }
-        catch (System.ArgumentException)
-        {
-            Console.WriteLine("Assembly load failure ({0}): ArgumentException", assemblyName);
-            return 102;
-        }
-        catch (BadImageFormatException e)
-        {
-            Console.WriteLine("Assembly load failure ({0}): BadImageFormatException (is it a managed assembly?)", assemblyName);
-            Console.WriteLine(e);
-            return 103;
-        }
-        catch (System.IO.FileLoadException)
-        {
-            Console.WriteLine("Assembly load failure ({0}): FileLoadException", assemblyName);
-            return 104;
-        }
-        catch (System.IO.FileNotFoundException)
-        {
-            Console.WriteLine("Assembly load failure ({0}): file not found", assemblyName);
-            return 105;
-        }
-        catch (System.UnauthorizedAccessException)
-        {
-            Console.WriteLine("Assembly load failure ({0}): UnauthorizedAccessException", assemblyName);
-            return 106;
-        }
-
-        aTypes = new List<Type>();
-
-        var globalMethods = aAssem.ManifestModule.GetMethods(BindingFlagsForCollectingAllMethodsOrCtors);
-        if (globalMethods.Length > 0)
-        {
-            GlobalMethodHolder.PopulateGlobalMethodInfoSet(globalMethods);
-            aTypes.Add(typeof(GlobalMethodHolder));
-        }
-
-        try
-        {
-            aTypes.AddRange(aAssem.GetTypes());
-        }
-        catch (System.Reflection.ReflectionTypeLoadException e)
-        {
-            Console.WriteLine("tReflectionTypeLoadException {0}", assemblyName);
-            Exception[] ea = e.LoaderExceptions;
-            foreach (Exception e2 in ea)
-            {
-                string[] ts = e2.ToString().Split('\'');
-                string temp = ts[1];
-                ts = temp.Split(',');
-                temp = ts[0];
-
-                Console.WriteLine("tReflectionTypeLoadException {0} {1}", temp, assemblyName);
-            }
-            return 107;
-        }
-        catch (System.IO.FileLoadException)
-        {
-            Console.WriteLine("tFileLoadException {0}", assemblyName);
-            return 108;
-        }
-        catch (System.IO.FileNotFoundException e)
-        {
-            string temp = e.ToString();
-            string[] ts = temp.Split('\'');
-            temp = ts[1];
-            Console.WriteLine("tFileNotFoundException {1} {0}", temp, assemblyName);
-            return 109;
-        }
-
-        switch (command)
-        {
-            case "COUNT":
-                {
-                    int typeCount = 0;
-                    int methodCount = 0;
-
-                    Console.WriteLine("Computing Count for {0}", assemblyName);
-
-                    foreach (Type t in aTypes)
-                    {
-                        Console.WriteLine("#types: {0}, #methods: {1}, before type {2}", typeCount, methodCount, t.FullName);
-                        MicroMethodInfo[] rmh = GetRMH(t);
-                        methodCount += rmh.Length;
-                        typeCount++;
-                    }
-
-                    TimeSpan elapsed = DateTime.Now - start;
-                    Console.WriteLine("Counts {0} - #types: {1}, #methods: {2}, elapsed time: {3}, elapsed ms: {4}",
-                        assemblyName, typeCount, methodCount, elapsed, elapsed.TotalMilliseconds);
-                    return 0;
                 }
 
-            case "PREPALL":
+                if (command == "PREPALL")
                 {
-                    // Call PrepareMethod on all methods in the given assembly
-                    int typeCount = 0;
-                    int methodCount = 0;
-                    string pmiFullLogFileName = String.Format("{0}.pmi", Path.GetFileNameWithoutExtension(assemblyName));
-                    string pmiPartialLogFileName = String.Format("{0}.pmiPartial", Path.GetFileNameWithoutExtension(assemblyName));
-
-                    Console.WriteLine("Prepall for {0}", assemblyName);
-
-                    foreach (Type t in aTypes)
-                    {
-                        Console.WriteLine("Start type {0}", t.FullName);
-                        MicroMethodInfo[] amMI = GetRMH(t);
-                        DateTime startType = DateTime.Now;
-
-                        foreach (MicroMethodInfo mMI in amMI)
-                        {
-                            if (methodCount >= methodToPrep)
-                            {
-                                WriteAndFlushNextMethodToPrepMarker(methodCount);
-
-                                if (mMI.IsAbstract)
-                                {
-                                    Console.WriteLine("PREPALL type# {0} method# {1} {2}::{3} - skipping (abstract)", typeCount, methodCount, t.FullName, mMI.name);
-                                }
-                                else if (mMI.ContainsGenericParameters)
-                                {
-                                    Console.WriteLine("PREPALL type# {0} method# {1} {2}::{3} - skipping (generic parameters)", typeCount, methodCount, t.FullName, mMI.name);
-                                }
-                                else
-                                {
-                                    Console.Write("PREPALL type# {0} method# {1} {2}::{3}", typeCount, methodCount, t.FullName, mMI.name);
-                                    TimeSpan elapsedFunc = PrepareMethod(t, mMI);
-                                    if (elapsedFunc != TimeSpan.MinValue)
-                                    {
-                                        Console.WriteLine(", elapsed time: {0}, elapsed ms: {1}",
-                                            elapsedFunc, elapsedFunc.TotalMilliseconds);
-                                    }
-                                }
-                            }
-
-                            methodCount++;
-                        }
-
-                        TimeSpan elapsedType = DateTime.Now - startType;
-                        Console.WriteLine("Completed type {0}, type elapsed time: {1}, elapsed ms: {2}",
-                            t.FullName, elapsedType, elapsedType.TotalMilliseconds);
-
-                        typeCount++;
-                    }
-
-                    TimeSpan elapsed = DateTime.Now - start;
-                    Console.WriteLine("Completed assembly {0} - #types: {1}, #methods: {2}, elapsed time: {3}, elapsed ms: {4}",
-                        assemblyName, typeCount, methodCount, elapsed, elapsed.TotalMilliseconds);
-                    return 0;
+                    v = new PrepareAll(methodToPrep);
                 }
-
-            case "PREPONE":
+                else
                 {
-                    // Call PrepareMethod on a single method
-
-                    Console.WriteLine("PrepOne for {0} {1}", assemblyName, methodToPrep);
-
-                    foreach (Type t in aTypes)
-                    {
-                        Console.WriteLine("Start type {0}", t.FullName);
-
-                        int methodCount2 = GetRMHCountOnly(t);
-
-                        if (methodCount2 > methodToPrep)
-                        {
-                            MicroMethodInfo[] amMI = GetRMH(t);
-
-                            Console.Write("Preparing method {0}::{1}", t.FullName, amMI[methodToPrep].name);
-
-                            TimeSpan elapsedFunc = PrepareMethod(t, amMI[methodToPrep]);
-                            if (elapsedFunc != TimeSpan.MinValue)
-                            {
-                                Console.WriteLine(", elapsed time: {0}, elapsed ms: {1}",
-                                    elapsedFunc, elapsedFunc.TotalMilliseconds);
-                            }
-
-                            TimeSpan elapsed = DateTime.Now - start;
-                            Console.WriteLine("Completed assembly {0} - #types: {1}, #methods: {2}, elapsed time: {3}, elapsed ms: {4}",
-                                assemblyName, 1, 1, elapsed, elapsed.TotalMilliseconds);
-                            return 0;
-                        }
-                        else
-                        {
-                            methodToPrep -= methodCount2;
-                        }
-                    }
-
-                    Console.WriteLine("Didn't find a method #{0} in {1}", args[2], assemblyName);
-                    return 0;
+                    v = new PrepareOne(methodToPrep);
                 }
+                break;
 
             default:
-                {
-                    Console.WriteLine("ERROR: Unknown command {0}", command);
-                    return 101;
-                }
+                Console.WriteLine("ERROR: Unknown command {0}", command);
+                return Usage();
         }
+
+        Worker w = new Worker(v);
+        int result = w.Work(assemblyName);
+        return result;
     }
 }

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 //
 // In .Net Core, PrepareMethod should give codegen that is very similar to
 // the code one would see if the method were actually called (the same is not
-// as true in .Net Framework -- in paritcular the jit may make very different
+// as true in .Net Framework -- in particular the jit may make very different
 // inlining decisions).
 //
 // Assemblies defining generic types and generic methods require special handling.


### PR DESCRIPTION
This change adds the ability for PMI to create instantations of some
generic types (limited to types with one or two parameters only for now).

Because of constraints it is not possible to easily tell in advance how
many instantations will result. Also in the future we will want to do
something similar for generic methods, and may want to produce different
kinds of output markup.

So this change also refactors the PMI code to use a visitor pattern for
traversing types and methods. Three concrete visitors are implemented:
one for counting types and methods, one for jitting a range of methods, and
one for jitting just a single method.

The actual strategy for instantiating generics is held in the `Worker` class.
We attempt up to 4 instantations of single parameter types and 8 of two
parameter types, with a mixture of types. There is room for enhancement here,
both in trying out suitable struct types and in looking for types that will
satisfy various constraints. A limited amount of constraint validation is
done up front.

Aside from extra methods and types seen via instantations this should be
functionally equivalent to the base version.