### PR TITLE
Some minor usability tweaks in jitutils

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -401,6 +401,11 @@ namespace ManagedCodeGen
 
                     GenerateAsmInternal();
                 }
+                catch(Exception e)
+                {
+                    Console.WriteLine($"JIT DASM PMI failed: {e.Message}");
+                    _errorCount++;
+                }
                 finally
                 {
                     if (_config.CopyJit)

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -263,6 +263,10 @@ namespace ManagedCodeGen
                     analysisArgs.Add("--diff");
                     analysisArgs.Add(Path.Combine(config.OutputPath, "diff"));
                     analysisArgs.Add("--recursive");
+                    analysisArgs.Add("--note");
+
+                    string jitName = config.AltJit ?? "default jit";
+                    analysisArgs.Add($"{diffString} for {config.Arch} {jitName}");
 
                     if (config.Verbose)
                     {

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -445,13 +445,20 @@ namespace ManagedCodeGen
                             {
                                 _basePath = tryBasePath;
                                 needBasePath = false;
-                                Console.WriteLine("Using --base={0}", _basePath);
+                                Console.WriteLine($"Using --base={_basePath}");
                             }
+
                             if (tryDiffPath != null)
                             {
                                 _diffPath = tryDiffPath;
                                 needDiffPath = false;
-                                Console.WriteLine("Using --diff={0}", _diffPath);
+                                Console.WriteLine($"Using --diff={_diffPath}");
+                            }
+
+                            if (_arch == null)
+                            {
+                                _arch = arch;
+                                Console.WriteLine($"Using --arch={_arch}");
                             }
                             break;
                         }
@@ -1194,7 +1201,7 @@ namespace ManagedCodeGen
             public string Number { get { return _number; } }
             public string BranchName { get { return _branchName; } }
             public string AltJit { get { return _altjit; } }
-
+            public string Arch {  get { return _arch;  } }
             public string AssemblyName => _assemblyName;
         }
 

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -945,6 +945,13 @@ class PrepareMethodinator
     {
         string exeName = System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName; // get the current full path name of PMI.exe
         exeName = System.IO.Path.GetFileName(exeName); // strip off the path; just use the EXE name.
+        // Augment if we're using core executables that require an explicit host.
+        // (note user may have actually launched via pmi.bat -- not clear how to tell that just yet).
+        if (exeName.IndexOf("dotnet") == 0 || exeName.IndexOf("corerun") == 0)
+        {
+            exeName += " pmi.dll";
+        }
+
         Console.WriteLine(
             "Usage:\r\n"
             + "\r\n"


### PR DESCRIPTION
Have `jit-diff` pass a description string down to `jit-analyze` so the
summary can describe what was being diffed. Capture the arch that was
actually used and add it to the description.

Have `jit-analyze` accept that description string and display it in the
summary.

Remove a diagnostic "adding" message inadvertenly left in `jit-analyze`'s
processing of files with text diffs.

Don't show final file diff (but no size diff) message in the analysis
summary if there were no such files (which is commonly the case).

Update Usage for `pmi` to indicate you must pass `pmi.dll` as the first arg
to your launcher if you launched via `dotnet` or `corerun`. This should
partially address #140.

Add a bit more EH to `jit-dasm-pmi` in a attempt to reduce the volume of
dotnet failure popup dialogs (seen when altjit asserts cause crashes). More
is needed here to make this fully robust.