### PR TITLE
Fix a couple of quirks with status bar

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -487,7 +487,11 @@ namespace ManagedCodeGen
                         // Here's one place where rationalized jit naming would be nice.
                         if (_altjit.IndexOf("nonjit") > 0)
                         {
-                            Console.WriteLine("Setting SIMD Length to 16");
+                            if (this.verbose)
+                            {
+                                Console.WriteLine("Setting SIMD Length to 16");
+                            }
+
                             generateCmd.EnvironmentVariable("COMPlus_SIMD16ByteOnly", "1");
                         }
 

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -636,7 +636,7 @@ namespace ManagedCodeGen
                             StartDasmWorkOne(DasmWorkKind.Base, commandArgs, "base", m_config.BasePath, assemblyInfo);
                         }
 
-                        progressBar.AwaitTasksAndShowProgress(assemblyWorkList, m_config, DasmWorkTasks, m_config.DoDiffCompiles);
+                        progressBar.AwaitTasksAndShowProgress(assemblyWorkList, m_config, DasmWorkTasks, !m_config.DoDiffCompiles);
                     }
                     finally
                     {


### PR DESCRIPTION
When using altjit, don't print the SIMD message by default.
Base runs are the last set when there aren't any diff runs.