### PR TITLE
jit-pmi-diff: disable tiering by default

### DIFF
--- a/src/jit-analyze/README.md
+++ b/src/jit-analyze/README.md
@@ -40,7 +40,7 @@ Top file improvements by size (bytes):
 
 21 total files with diffs.
 
-Top method regessions by size (bytes):
+Top method regressions by size (bytes):
     328 : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DocumentationCommentXmlTokens:.cctor()
     266 : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.MethodTypeInferrer:Fix(int,byref):bool:this
     194 : mscorlib.dasm - System.DefaultBinder:BindToMethod(int,ref,byref,ref,ref,ref,byref):ref:this

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -434,7 +434,7 @@ namespace ManagedCodeGen
 
             if (methodRegressionCount > 0)
             {
-                Console.WriteLine("\nTop method regessions by size (bytes):");
+                Console.WriteLine("\nTop method regressions by size (bytes):");
 
                 foreach (var method in sortedMethodRegressions.GetRange(0, Math.Min(methodRegressionCount, requestedCount)))
                 {

--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -42,6 +42,7 @@ namespace ManagedCodeGen
         private bool _dumpGCInfo = false;
         private bool _noCopyJit = false;
         private bool _verbose = false;
+        private bool _tiering = false;
 
         public Config(string[] args)
         {
@@ -54,6 +55,7 @@ namespace ManagedCodeGen
                 syntax.DefineOption("f|file", ref _fileName, "Name of file to take list of assemblies from. Both a file and assembly list can be used.");
                 syntax.DefineOption("gcinfo", ref _dumpGCInfo, "Add GC info to the disasm output.");
                 syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
+                syntax.DefineOption("t|tiering", ref _tiering, "Enable tiered jitting");
                 syntax.DefineOption("r|recursive", ref _recursive, "Scan directories recursively.");
                 syntax.DefineOptionList("p|platform", ref _platformPaths, "Path to platform assemblies");
 
@@ -147,6 +149,7 @@ namespace ManagedCodeGen
         public IReadOnlyList<string> PlatformPaths { get { return _platformPaths; } }
         public string FileName { get { return _fileName; } }
         public IReadOnlyList<string> AssemblyList { get { return _assemblyList; } }
+        public bool Tiering => _tiering;
     }
 
     public class AssemblyInfo
@@ -479,6 +482,9 @@ namespace ManagedCodeGen
                     AddEnvironmentVariable("COMPlus_JitUnwindDump", "*");
                     AddEnvironmentVariable("COMPlus_JitEHDump", "*");
                     AddEnvironmentVariable("COMPlus_JitDiffableDasm", "1");
+                    
+                    // We likely don't want tiering enabled, but allow it, if user asks for it.
+                    AddEnvironmentVariable("COMPlus_TieredCompilation", _config.Tiering ? "1" : "0");
 
                     if (this.doGCDump)
                     {


### PR DESCRIPTION
Turn off tiering by default for when invoking PMI. Can enable via -tiering.

Also, fix a couple of spelling errors.