### PR TITLE
PMI: Improve constraint checking logic

### DIFF
--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -890,7 +890,7 @@ class Worker
 
             foreach (Type c in constraints)
             {
-                // If the constrant is also generic, just bail on checks.
+                // If the constraint is also generic, just bail on checks.
                 // The runtime checks will determine if this constraint is satisfied.
                 if (c.ContainsGenericParameters)
                 {


### PR DESCRIPTION
The logic to check for generic parameter type constraints was wrong.
If the constraint it itself generic then just skip checking and let
the runtime figure it out.

Handle the other classes of special constraint. Fix the check for the
class/interface constraint.

Add `long` to the types we try and use for instantiations since it
stresses x86.