### PR TITLE
Avoid re-reading .dasm files

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -232,7 +232,7 @@ namespace ManagedCodeGen
                          {
                              path = p.Substring(fullRootPath.Length).TrimStart(Path.DirectorySeparatorChar),
                              methodList = ExtractMethodInfo(p)
-                         });
+                         }).ToList();
             }
             else
             {
@@ -329,7 +329,7 @@ namespace ManagedCodeGen
                 }
 
                 return f;
-            });
+            }).ToList();
         }
 
         // Summarize differences across all the files.


### PR DESCRIPTION
Isn't LINQ nice when re-evaluating a query results in re-reading gigabytes of data from disk?