### PR TITLE
Call GC.WaitForPendingFinalizer before PrepareMethod

### DIFF
--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -254,6 +254,7 @@ abstract class PrepareBase : CounterBase
         try
         {
             DateTime startFunc = DateTime.Now;
+            GC.WaitForPendingFinalizers();
             System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(method.MethodHandle);
             elapsedFunc = DateTime.Now - startFunc;
         }


### PR DESCRIPTION
This seems to be sufficient to prevent JIT output corruption by the finalizer thread triggering a finalizer method compilation (e.g. such as in https://github.com/dotnet/jitutils/issues/164). Tested on Linux/arm Linux/x64 by pmi-ing S.P.C.dll

@mikedn @AndyAyersMS @BruceForstall PTAL

If the problem comes back would also try @mikedn's NoGCRegion suggestion  https://github.com/dotnet/jitutils/issues/164#issuecomment-416826491

/cc @dotnet/jit-contrib 