### PR TITLE
Add option to dump debug info to jit-diffs

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -40,6 +40,7 @@ namespace ManagedCodeGen
         private IReadOnlyList<string> _methods = Array.Empty<string>();
         private IReadOnlyList<string> _platformPaths = Array.Empty<string>();
         private bool _dumpGCInfo = false;
+        private bool _dumpDebugInfo = false;
         private bool _noCopyJit = false;
         private bool _verbose = false;
         private bool _tiering = false;
@@ -54,6 +55,7 @@ namespace ManagedCodeGen
                 syntax.DefineOption("o|output", ref _rootPath, "The output path.");
                 syntax.DefineOption("f|file", ref _fileName, "Name of file to take list of assemblies from. Both a file and assembly list can be used.");
                 syntax.DefineOption("gcinfo", ref _dumpGCInfo, "Add GC info to the disasm output.");
+                syntax.DefineOption("debuginfo", ref _dumpDebugInfo, "Add Debug info to the disasm output.");
                 syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
                 syntax.DefineOption("t|tiering", ref _tiering, "Enable tiered jitting");
                 syntax.DefineOption("r|recursive", ref _recursive, "Scan directories recursively.");
@@ -140,6 +142,7 @@ namespace ManagedCodeGen
         public bool Recursive { get { return _recursive; } }
         public bool UseFileName { get { return (_fileName != null); } }
         public bool DumpGCInfo { get { return _dumpGCInfo; } }
+        public bool DumpDebugInfo { get { return _dumpDebugInfo; } }
         public bool DoVerboseOutput { get { return _verbose; } }
         public bool CopyJit { get { return !_noCopyJit; } }
         public string CorerunExecutable { get { return _corerunExe; } }
@@ -346,6 +349,7 @@ namespace ManagedCodeGen
             private string _altjit = null;
             private List<AssemblyInfo> _assemblyInfoList;
             public bool doGCDump = false;
+            public bool doDebugDump = false;
             public bool verbose = false;
             private int _errorCount = 0;
 
@@ -370,6 +374,7 @@ namespace ManagedCodeGen
                 _assemblyInfoList = assemblyInfoList;
 
                 this.doGCDump = config.DumpGCInfo;
+                this.doDebugDump = config.DumpDebugInfo;
                 this.verbose = config.DoVerboseOutput;
             }
 
@@ -491,6 +496,11 @@ namespace ManagedCodeGen
                     if (this.doGCDump)
                     {
                         AddEnvironmentVariable("COMPlus_JitGCDump", "*");
+                    }
+
+                    if (this.doDebugDump)
+                    {
+                        AddEnvironmentVariable("COMPlus_JitDebugDump", "*");
                     }
 
                     if (this._altjit != null)

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -366,7 +366,7 @@ namespace ManagedCodeGen
                 _assemblyInfoList = assemblyInfoList;
 
                 this.doGCDump = config.DumpGCInfo;
-                this.doDebugDump = config.DumpGCInfo;
+                this.doDebugDump = config.DumpDebugInfo;
                 this.verbose = config.DoVerboseOutput;
             }
 

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -47,6 +47,7 @@ namespace ManagedCodeGen
         private IReadOnlyList<string> _methods = Array.Empty<string>();
         private IReadOnlyList<string> _platformPaths = Array.Empty<string>();
         private bool _dumpGCInfo = false;
+        private bool _dumpDebugInfo = false;
         private bool _verbose = false;
 
         public Config(string[] args)
@@ -59,6 +60,7 @@ namespace ManagedCodeGen
                 syntax.DefineOption("o|output", ref _rootPath, "The output path.");
                 syntax.DefineOption("f|file", ref _fileName, "Name of file to take list of assemblies from. Both a file and assembly list can be used.");
                 syntax.DefineOption("gcinfo", ref _dumpGCInfo, "Add GC info to the disasm output.");
+                syntax.DefineOption("debuginfo", ref _dumpDebugInfo, "Add Debug info to the disasm output.");
                 syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
                 var waitArg = syntax.DefineOption("w|wait", ref _wait, "Wait for debugger to attach.");
                 waitArg.IsHidden = true;
@@ -141,6 +143,7 @@ namespace ManagedCodeGen
         public bool Recursive { get { return _recursive; } }
         public bool UseFileName { get { return (_fileName != null); } }
         public bool DumpGCInfo { get { return _dumpGCInfo; } }
+        public bool DumpDebugInfo { get { return _dumpDebugInfo; } }
         public bool DoVerboseOutput { get { return _verbose; } }
         public string CrossgenExecutable { get { return _crossgenExe; } }
         public string JitPath { get { return _jitPath; } }
@@ -345,6 +348,7 @@ namespace ManagedCodeGen
             private string _altjit = null;
             private List<AssemblyInfo> _assemblyInfoList;
             public bool doGCDump = false;
+            public bool doDebugDump = false;
             public bool verbose = false;
             private int _errorCount = 0;
 
@@ -362,6 +366,7 @@ namespace ManagedCodeGen
                 _assemblyInfoList = assemblyInfoList;
 
                 this.doGCDump = config.DumpGCInfo;
+                this.doDebugDump = config.DumpGCInfo;
                 this.verbose = config.DoVerboseOutput;
             }
 
@@ -469,6 +474,11 @@ namespace ManagedCodeGen
                     if (this.doGCDump)
                     {
                         AddEnvironmentVariable("COMPlus_NgenGCDump", "*");
+                    }
+
+                    if (this.doDebugDump)
+                    {
+                        AddEnvironmentVariable("COMPlus_NgenDebugDump", "*");
                     }
 
                     if (this._altjit != null)

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -300,6 +300,11 @@ namespace ManagedCodeGen
                     commandArgs.Add("--gcinfo");
                 }
 
+                if (config.GenerateDebugInfo)
+                {
+                    commandArgs.Add("--debuginfo");
+                }
+
                 if (config.Verbose)
                 {
                     commandArgs.Add("--verbose");

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -135,6 +135,7 @@ namespace ManagedCodeGen
             private bool _benchmarks = false;
             private bool _tests = false;
             private bool _gcinfo = false;
+            private bool _debuginfo = false;
             private bool _verbose = false;
             private string _jobName = null;
             private string _number = null;
@@ -178,6 +179,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("benchmarks", ref _benchmarks, "Diff core benchmarks.");
                     syntax.DefineOption("tests", ref _tests, "Diff all tests.");
                     syntax.DefineOption("gcinfo", ref _gcinfo, "Add GC info to the disasm output.");
+                    syntax.DefineOption("debuginfo", ref _debuginfo, "Add Debug info to the disasm output.");
                     syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
                     syntax.DefineOption("core_root", ref _platformPath, "Path to test CORE_ROOT.");
                     syntax.DefineOption("test_root", ref _testPath, "Path to test tree. Use with --benchmarks or --tests.");
@@ -1085,6 +1087,10 @@ namespace ManagedCodeGen
                     var gcinfo = ExtractDefault<bool>("gcinfo", out found);
                     _gcinfo = (found) ? gcinfo : _gcinfo;
 
+                    // Set flag from default for debuginfo.
+                    var debuginfo = ExtractDefault<bool>("debuginfo", out found);
+                    _debuginfo = (found) ? debuginfo : _debuginfo;
+
                     // Set flag from default for tag.
                     var tag = ExtractDefault<string>("tag", out found);
                     _tag = (found) ? tag : _tag;
@@ -1167,6 +1173,7 @@ namespace ManagedCodeGen
                     PrintDefault("benchmarks", DefaultType.DT_bool);
                     PrintDefault("tests", DefaultType.DT_bool);
                     PrintDefault("gcinfo", DefaultType.DT_bool);
+                    PrintDefault("debuginfo", DefaultType.DT_bool);
                     PrintDefault("tag", DefaultType.DT_string);
                     PrintDefault("verbose", DefaultType.DT_bool);
 
@@ -1221,6 +1228,7 @@ namespace ManagedCodeGen
             public bool Benchmarks { get { return _benchmarks; } }
             public bool DoTestTree { get { return _tests; } }
             public bool GenerateGCInfo { get { return _gcinfo; } }
+            public bool GenerateDebugInfo { get { return _debuginfo; } }
             public bool Verbose { get { return _verbose; } }
             public bool DoAnalyze { get { return !_noanalyze; } }
             public Commands DoCommand { get { return _command; } }


### PR DESCRIPTION
Off by default. Enable via --debuginfo.

Info is dumped after the method (like unwind and eh) and will show up
as file diffs.