### PR TITLE
Add `no-renames` to git diff.

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -627,6 +627,7 @@ namespace ManagedCodeGen
             commandArgs.Add("--no-index");
             commandArgs.Add("--exit-code");
             commandArgs.Add("--numstat");
+            commandArgs.Add("--no-renames");
             commandArgs.Add(diffPath);
             commandArgs.Add(basePath);
             Command diffCmd = null;


### PR DESCRIPTION
Fix issue with jitutils running under git controlled folder where `git diff` shrinks first symbols from diff paths and it ends up in:
git returns 
`0       1       {iff => ase}/1.txt` <- wrong
instead of 
`1       1       "C:\\diff/1.txt" => "C:\\base/1.txt"` <- correct
and jitutils return:
`Couldn't parse --numstat output '1697   1697    iffs/diffout/dasmset_21/{diff => base}/System.Private.CoreLib.dasm` : 'C:\git\tools\jitutils\bin\iffs\diffout\dasmset_21\{diff' does not exist`

cc @dotnet/jit-contrib 