### PR TITLE
jit-analyze: add percentage improved/regressed display for functions

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -386,12 +386,12 @@ namespace ManagedCodeGen
             int sortedFileCount = fileImprovementCount + fileRegressionCount;
             int unchangedFileCount = fileDeltaList.Count() - sortedFileCount;
 
-            void DisplayFileMetric(string headerText, int metric, dynamic list)
+            void DisplayFileMetric(string headerText, int metricCount, dynamic list)
             {
-                if (metric > 0)
+                if (metricCount > 0)
                 {
                     Console.WriteLine(headerText);
-                    foreach (var fileDelta in list.GetRange(0, Math.Min(metric, requestedCount)))
+                    foreach (var fileDelta in list.GetRange(0, Math.Min(metricCount, requestedCount)))
                     {
                         Console.WriteLine("    {1,8} : {0} ({2:P} of base)", fileDelta.basePath,
                             fileDelta.deltaBytes, (double)fileDelta.deltaBytes / fileDelta.baseBytes);
@@ -434,12 +434,12 @@ namespace ManagedCodeGen
                                             .Where(x => x.deltaBytes > 0)
                                             .OrderByDescending(d => (double)d.deltaBytes / d.baseBytes).ToList();
 
-            void DisplayMethodMetric(string headerText, int metric, dynamic list)
+            void DisplayMethodMetric(string headerText, int metricCount, dynamic list)
             {
-                if (metric > 0)
+                if (metricCount > 0)
                 {
                     Console.WriteLine(headerText);
-                    foreach (var method in list.GetRange(0, Math.Min(metric, requestedCount)))
+                    foreach (var method in list.GetRange(0, Math.Min(metricCount, requestedCount)))
                     {
                         Console.Write("    {2,8} ({3,6:P} of base) : {0} - {1}", method.path, method.name, method.deltaBytes,
                             (double)method.deltaBytes / method.baseBytes);
@@ -453,7 +453,7 @@ namespace ManagedCodeGen
                         }
                         else
                         {
-                            Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
+                            Console.Write(" ({0} base, {1} diff methods)", method.baseCount, method.diffCount);
                         }
                         Console.WriteLine();
                     }

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -335,9 +335,9 @@ namespace ManagedCodeGen
         // Summarize differences across all the files.
         // Output:
         //     Total bytes differences
-        //     Top 5 files by difference size
-        //     Top 5 diffs by size across all files
-        //
+        //     Top files by difference size
+        //     Top diffs by size across all files
+        //     Top diffs by percentage size across all files
         //
         public static int Summarize(IEnumerable<FileDelta> fileDeltaList, Config config, Dictionary<string, int> diffCounts)
         {
@@ -386,26 +386,21 @@ namespace ManagedCodeGen
             int sortedFileCount = fileImprovementCount + fileRegressionCount;
             int unchangedFileCount = fileDeltaList.Count() - sortedFileCount;
 
-            if (fileRegressionCount > 0)
+            void DisplayFileMetric(string headerText, int metric, dynamic list)
             {
-                Console.WriteLine("\nTop file regressions by size (bytes):");
-                foreach (var fileDelta in sortedFileRegressions.GetRange(0, Math.Min(fileRegressionCount, requestedCount)))
+                if (metric > 0)
                 {
-                    Console.WriteLine("    {1,8} : {0} ({2:P} of base)", fileDelta.basePath,
-                        fileDelta.deltaBytes, (double)fileDelta.deltaBytes / fileDelta.baseBytes);
+                    Console.WriteLine(headerText);
+                    foreach (var fileDelta in list.GetRange(0, Math.Min(metric, requestedCount)))
+                    {
+                        Console.WriteLine("    {1,8} : {0} ({2:P} of base)", fileDelta.basePath,
+                            fileDelta.deltaBytes, (double)fileDelta.deltaBytes / fileDelta.baseBytes);
+                    }
                 }
             }
 
-            if (fileImprovementCount > 0)
-            {
-                Console.WriteLine("\nTop file improvements by size (bytes):");
-
-                foreach (var fileDelta in sortedFileImprovements.GetRange(0, Math.Min(fileImprovementCount, requestedCount)))
-                {
-                    Console.WriteLine("    {1,8} : {0} ({2:P} of base)", fileDelta.basePath,
-                        fileDelta.deltaBytes, (double)fileDelta.deltaBytes / fileDelta.baseBytes);
-                }
-            }
+            DisplayFileMetric("\nTop file regressions by size (bytes):", fileRegressionCount, sortedFileRegressions);
+            DisplayFileMetric("\nTop file improvements by size (bytes):", fileImprovementCount, sortedFileImprovements);
 
             Console.WriteLine("\n{0} total files with size differences ({1} improved, {2} regressed), {3} unchanged.",
                 sortedFileCount, fileImprovementCount, fileRegressionCount, unchangedFileCount);
@@ -432,53 +427,43 @@ namespace ManagedCodeGen
             int sortedMethodCount = methodImprovementCount + methodRegressionCount;
             int unchangedMethodCount = fileDeltaList.Sum(x => x.methodsInBoth) - sortedMethodCount;
 
-            if (methodRegressionCount > 0)
+            var sortedMethodImprovementsByPercentage = methodDeltaList
+                                            .Where(x => x.deltaBytes < 0)
+                                            .OrderBy(d => (double)d.deltaBytes / d.baseBytes).ToList();
+            var sortedMethodRegressionsByPercentage = methodDeltaList
+                                            .Where(x => x.deltaBytes > 0)
+                                            .OrderByDescending(d => (double)d.deltaBytes / d.baseBytes).ToList();
+
+            void DisplayMethodMetric(string headerText, int metric, dynamic list)
             {
-                Console.WriteLine("\nTop method regressions by size (bytes):");
-
-                foreach (var method in sortedMethodRegressions.GetRange(0, Math.Min(methodRegressionCount, requestedCount)))
+                if (metric > 0)
                 {
-                    Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
-
-                    if (method.baseCount == method.diffCount)
+                    Console.WriteLine(headerText);
+                    foreach (var method in list.GetRange(0, Math.Min(metric, requestedCount)))
                     {
-                        if (method.baseCount > 1)
+                        Console.Write("    {2,8} ({3,6:P} of base) : {0} - {1}", method.path, method.name, method.deltaBytes,
+                            (double)method.deltaBytes / method.baseBytes);
+
+                        if (method.baseCount == method.diffCount)
                         {
-                            Console.Write(" ({0} methods)", method.baseCount);
+                            if (method.baseCount > 1)
+                            {
+                                Console.Write(" ({0} methods)", method.baseCount);
+                            }
                         }
+                        else
+                        {
+                            Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
+                        }
+                        Console.WriteLine();
                     }
-                    else
-                    {
-                        Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
-                    }
-
-                    Console.WriteLine();
                 }
             }
 
-            if (methodImprovementCount > 0)
-            {
-                Console.WriteLine("\nTop method improvements by size (bytes):");
-
-                foreach (var method in sortedMethodImprovements.GetRange(0, Math.Min(methodImprovementCount, requestedCount)))
-                {
-                    Console.Write("    {2,8} : {0} - {1}", method.path, method.name, method.deltaBytes);
-
-                    if (method.baseCount == method.diffCount)
-                    {
-                        if (method.baseCount > 1)
-                        {
-                            Console.Write(" ({0} methods)", method.baseCount);
-                        }
-                    }
-                    else
-                    {
-                        Console.Write(" ({0}/{1} methods)", method.baseCount, method.diffCount);
-                    }
-
-                    Console.WriteLine();
-                }
-            }
+            DisplayMethodMetric("\nTop method regressions by size (bytes):", methodRegressionCount, sortedMethodRegressions);
+            DisplayMethodMetric("\nTop method improvements by size (bytes):", methodImprovementCount, sortedMethodImprovements);
+            DisplayMethodMetric("\nTop method regressions by size (percentage):", methodRegressionCount, sortedMethodRegressionsByPercentage);
+            DisplayMethodMetric("\nTop method improvements by size (percentage):", methodImprovementCount, sortedMethodImprovementsByPercentage);
 
             Console.WriteLine("\n{0} total methods with size differences ({1} improved, {2} regressed), {3} unchanged.",
                 sortedMethodCount, methodImprovementCount, methodRegressionCount, unchangedMethodCount);


### PR DESCRIPTION
This makes it much easier to find a small function with big impact
to analyze further, as opposed to looking at a large impact in a
very large function.

Also added percentage difference to the improved/regressed function
output for the functions ordered purely by size.

Sample percentage output:
```
Top method regressions by size (percentage):
          17 (13.08% of base) : System.Data.Common.dasm - DataColumnCollection:FinishInitCollection():this
          25 (13.02% of base) : Microsoft.DotNet.ProjectModel.dasm - FrameworkReferenceResolver:GetFrameworkInformation(ref):ref:this
          32 (12.60% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - DirectoryUtilities:Clean(ref):int
          33 ( 8.55% of base) : System.Private.DataContractSerialization.dasm - XmlDictionaryReader:ReadContentAs(ref,ref):ref:this
          20 ( 8.37% of base) : Microsoft.CodeAnalysis.dasm - MetadataHelpers:SplitQualifiedName(ref,byref):ref

Top method improvements by size (percentage):
         -81 (-56.25% of base) : System.Data.Common.dasm - SqlDecimal:MpMove(ref,int,ref,byref)
        -203 (-53.70% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,double,int,int):int:this
         -75 (-52.45% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,int,int,int):int:this
         -75 (-52.45% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:IndexOf(ref,long,int,int):int:this
        -138 (-51.88% of base) : Microsoft.CodeAnalysis.dasm - Hash:GetFNVHashCode(ref,int,int):int (2 methods)
```