### PR TITLE
Extend jit-diff `--assembly` argument

### DIFF
--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -279,10 +279,11 @@ namespace ManagedCodeGen
                     needPrefix = true;
                 }
 
-                if (config.AssemblyName != null)
+                foreach (string assembly in config.AssemblyList)
                 {
                     if (needPrefix) diffString += ", ";
-                    diffString += Path.GetFileName(config.AssemblyName);
+                    diffString += assembly;
+                    needPrefix = true;
                 }
 
                 Console.WriteLine($"Beginning {diffString}");
@@ -377,21 +378,26 @@ namespace ManagedCodeGen
             {
                 List<AssemblyInfo> assemblyInfoList = new List<AssemblyInfo>();
 
-                if (config.AssemblyName != null)
+                foreach (string assembly in config.AssemblyList)
                 {
-                    if (!File.Exists(config.AssemblyName))
+                    if (Directory.Exists(assembly))
                     {
-                        Console.Error.WriteLine($"Warning: can't find specified assembly {config.AssemblyName}");
+                        List<AssemblyInfo> directoryAssemblyInfoList = IdentifyAssemblies(assembly, assembly, config);
+                        assemblyInfoList.AddRange(directoryAssemblyInfoList);
                     }
-                    else
+                    else if (File.Exists(assembly))
                     {
                         AssemblyInfo info = new AssemblyInfo
                         {
-                            Path = config.AssemblyName,
+                            Path = assembly,
                             OutputPath = ""
                         };
 
                         assemblyInfoList.Add(info);
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Warning: can't find specified assembly or directory {assembly}");
                     }
                 }
 
@@ -641,7 +647,7 @@ namespace ManagedCodeGen
                 {
                     if (m_config.Verbose)
                     {
-                        Console.WriteLine($"Restoring exsiting jit: {backupJitPath} ==> {existingJitPath}");
+                        Console.WriteLine($"Restoring existing jit: {backupJitPath} ==> {existingJitPath}");
                     }
                     File.Copy(backupJitPath, existingJitPath, true);
                 }

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -145,7 +145,7 @@ namespace ManagedCodeGen
             private string _platformName = null;
             private string _branchName = null;
             private bool _pmi = false;
-            private string _assemblyName = null;
+            private IReadOnlyList<string> _assemblyList = Array.Empty<string>();
             private bool _tsv;
 
             private JObject _jObj;
@@ -189,7 +189,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("build", ref _build, "Build flavor to diff (Checked, Debug).");
                     syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., protononjit.dll).");
                     var pmiOption = syntax.DefineOption("pmi", ref _pmi, "Run asm diffs via pmi.");
-                    syntax.DefineOption("assembly", ref _assemblyName, "Run asm diffs on a particular assembly");
+                    syntax.DefineOptionList("assembly", ref _assemblyList, "Run asm diffs on a given set of assemblies. An individual item can be an assembly or a directory tree containing assemblies.");
                     syntax.DefineOption("tsv", ref _tsv, "Dump analysis data to diffs.tsv in output directory.");
                     // List command section.
                     syntax.DefineCommand("list", ref _command, Commands.List,
@@ -568,7 +568,7 @@ namespace ManagedCodeGen
                     }
                 }
 
-                if (!_corelib && !_frameworks && !_benchmarks && !_tests && (_assemblyName == null))
+                if (!_corelib && !_frameworks && !_benchmarks && !_tests && (_assemblyList.Count == 0))
                 {
                     // Setting --corelib as the default
                     Console.WriteLine("No assemblies specified; defaulting to corelib");
@@ -1241,7 +1241,7 @@ namespace ManagedCodeGen
             public string BranchName { get { return _branchName; } }
             public string AltJit { get { return _altjit; } }
             public string Arch {  get { return _arch;  } }
-            public string AssemblyName => _assemblyName;
+            public IReadOnlyList<string> AssemblyList => _assemblyList;
             public bool tsv {  get { return _tsv;  } }
         }
 


### PR DESCRIPTION
Two changes:
1. Allow you to specify multiple `--assembly` arguments; diffs will happen
for each specified assembly.
2. Allow an argument to `--assembly` to be a directory. In this case,
the directory tree will be searched for assemblies to diff.

E.g.,
```
jit-diff diff --pmi --base --diff --base_root f:\gh\coreclr12 --arch x64 --build Checked --assembly F:\gh\coreclr10\bin\tests\Windows_NT.x64.Release\JIT\jit64\localloc --assembly F:\gh\coreclr10\bin\tests\Windows_NT.x64.Checked\Tests\Core_Root\System.Collections.dll --assembly F:\gh\coreclr10\bin\tests\Windows_NT.x64.Checked\Tests\Core_Root\System.Collections.Specialized.dll
```