### PR TITLE
Set environment variables to assert on NO_WAY and noway_assert

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -489,6 +489,9 @@ namespace ManagedCodeGen
                     AddEnvironmentVariable("COMPlus_JitDiffableDasm", "1");
                     AddEnvironmentVariable("COMPlus_ReadyToRun", "0");
                     AddEnvironmentVariable("COMPlus_ZapDisable", "1");
+                    AddEnvironmentVariable("COMPlus_JitEnableNoWayAssert", "1");    // Force noway_assert to generate assert (not fall back to MinOpts).
+                    AddEnvironmentVariable("COMPlus_JitNoForceFallback", "1");      // Don't stress noway fallback path.
+                    AddEnvironmentVariable("COMPlus_JitRequired", "1");             // Force NO_WAY to generate assert. Also generates assert for BADCODE/BADCODE3.
                     
                     // We likely don't want tiering enabled, but allow it, if user asks for it.
                     AddEnvironmentVariable("COMPlus_TieredCompilation", _config.Tiering ? "1" : "0");

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -470,6 +470,9 @@ namespace ManagedCodeGen
                     AddEnvironmentVariable("COMPlus_NgenUnwindDump", "*");
                     AddEnvironmentVariable("COMPlus_NgenEHDump", "*");
                     AddEnvironmentVariable("COMPlus_JitDiffableDasm", "1");
+                    AddEnvironmentVariable("COMPlus_JitEnableNoWayAssert", "1");    // Force noway_assert to generate assert (not fall back to MinOpts).
+                    AddEnvironmentVariable("COMPlus_JitNoForceFallback", "1");      // Don't stress noway fallback path.
+                    AddEnvironmentVariable("COMPlus_JitRequired", "1");             // Force NO_WAY to generate assert. Also generates assert for BADCODE/BADCODE3.
 
                     if (this.doGCDump)
                     {


### PR DESCRIPTION
We don't want to allow JIT fallback to MinOpts when generating
asm diffs.