### PR TITLE
Add support for cctors mode to jit-diffs, jit-dasm-pmi, pmi

### DIFF
--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -317,7 +317,7 @@ namespace ManagedCodeGen
                     commandArgs.Add(config.AltJit);
                 }
 
-                if ((config.DoCommand == Commands.PmiDiff) && config.CCtors)
+                if ((config.DoCommand == Commands.PmiDiff) && config.Cctors)
                 {
                     commandArgs.Add("--cctors");
                     diffString += " [invoking .cctors]";

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -317,6 +317,12 @@ namespace ManagedCodeGen
                     commandArgs.Add(config.AltJit);
                 }
 
+                if ((config.DoCommand == Commands.PmiDiff) && config.CCtors)
+                {
+                    commandArgs.Add("--cctors");
+                    diffString += " [invoking .cctors]";
+                }
+
                 DateTime startTime = DateTime.Now;
                 List<AssemblyInfo> assemblyWorkList = GenerateAssemblyWorklist(config);
                 DasmResult dasmResult = diffTool.RunDasmTool(commandArgs, assemblyWorkList);

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -1245,7 +1245,7 @@ namespace ManagedCodeGen
             public string Arch {  get { return _arch;  } }
             public IReadOnlyList<string> AssemblyList => _assemblyList;
             public bool tsv {  get { return _tsv;  } }
-            public bool CCtors => _cctors;
+            public bool Cctors => _cctors;
         }
 
         private static string[] s_testDirectories =

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -147,6 +147,7 @@ namespace ManagedCodeGen
             private bool _pmi = false;
             private IReadOnlyList<string> _assemblyList = Array.Empty<string>();
             private bool _tsv;
+            private bool _cctors;
 
             private JObject _jObj;
             private bool _configFileLoaded = false;
@@ -189,6 +190,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("build", ref _build, "Build flavor to diff (Checked, Debug).");
                     syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., protononjit.dll).");
                     var pmiOption = syntax.DefineOption("pmi", ref _pmi, "Run asm diffs via pmi.");
+                    syntax.DefineOption("cctors", ref _cctors, "With --pmi, jit and run cctors before jitting other methods");
                     syntax.DefineOptionList("assembly", ref _assemblyList, "Run asm diffs on a given set of assemblies. An individual item can be an assembly or a directory tree containing assemblies.");
                     syntax.DefineOption("tsv", ref _tsv, "Dump analysis data to diffs.tsv in output directory.");
                     // List command section.
@@ -1243,6 +1245,7 @@ namespace ManagedCodeGen
             public string Arch {  get { return _arch;  } }
             public IReadOnlyList<string> AssemblyList => _assemblyList;
             public bool tsv {  get { return _tsv;  } }
+            public bool CCtors => _cctors;
         }
 
         private static string[] s_testDirectories =


### PR DESCRIPTION
Jit codegen can sometimes incorporate the values of initonly static fields.
These codegen diffs aren't usually visible to PMI as we haven't actually
initialized many classes.

Add an option to run class constructors for each discovered type to make it
more likely initonly static field values will be seen by the jit. Note cross-class
static accesses may or may not be picked up by this; we don't do anything clever
with the order of class initialization.

Closes #183.