### PR TITLE
Escape arguments line for `dotnet *.dll arguments` in our wrappers.

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 SOURCE=$BASH_SOURCE
-dotnet $SOURCE.dll $@
+dotnet $SOURCE.dll "$@"


### PR DESCRIPTION
Fixes jit-analyze that has multi words `--note` argument from jit-diff.

Example output for:
```
./bin/jit-diff diff 
-d ~/git/coreclr/bin/tests/Linux.x64.Checked/Tests/Core_Root_fast/ 
-b ~/git/coreclr/bin/tests/Linux.x64.Checked/Tests/Core_Root_slow/ 
--output ~/diffs 
--core_root ~/git/coreclr/bin/tests/Linux.x64.Checked/Tests/Core_Root --verbose
```

Before:

```
Analyze command: jit-analyze --base /home/sergey/diffs/dasmset_14/base --diff /home/sergey/diffs/dasmset_14/diff --recursive --note Crossgen Diffs for System.Private.CoreLib.dll for  default jit
Analyzing diffs...
--base /home/sergey/diffs/dasmset_14/base --diff /home/sergey/diffs/dasmset_14/diff --recursive --note Crossgen Diffs for System.Private.CoreLib.dll for default jit
our arg is: --base
our arg is: /home/sergey/diffs/dasmset_14/base
our arg is: --diff
our arg is: /home/sergey/diffs/dasmset_14/diff
our arg is: --recursive
our arg is: --note
our arg is: Crossgen
our arg is: Diffs
our arg is: for
our arg is: System.Private.CoreLib.dll
our arg is: for
our arg is: default
our arg is: jit
error: extra parameter 'Diffs'
Completed analysis in 0.09s
```

after:
```
Analyze command: jit-analyze --base /home/sergey/diffs/dasmset_13/base --diff /home/sergey/diffs/dasmset_13/diff --recursive --note Crossgen Diffs for System.Private.CoreLib.dll for  default jit
Analyzing diffs...
--base /home/sergey/diffs/dasmset_13/base --diff /home/sergey/diffs/dasmset_13/diff --recursive --note Crossgen Diffs for System.Private.CoreLib.dll for  default jit
our arg is: --base
our arg is: /home/sergey/diffs/dasmset_13/base
our arg is: --diff
our arg is: /home/sergey/diffs/dasmset_13/diff
our arg is: --recursive
our arg is: --note
our arg is: Crossgen Diffs for System.Private.CoreLib.dll for  default jit
Crossgen Diffs for System.Private.CoreLib.dll for  default jit
Summary:
(Lower is better)
Total bytes of diff: 0 (NaN of base)
0 total files with size differences (0 improved, 0 regressed), 1 unchanged.
0 total methods with size differences (0 improved, 0 regressed), 0 unchanged.
Completed analysis in 0.15s
```



PTAL @dotnet/jit-contrib 

contributes to #186