### PR TITLE
Use net core app3 if available

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -15,7 +15,6 @@ set fxInstallDir=%scriptDir%fx
 set buildType=Release
 set publish=false
 set fx=false
-set tfm=netcoreapp2.1
 
 for /f "usebackq tokens=1,2" %%a in (`dotnet --info`) do (
     if "%%a"=="RID:" set platform=%%b
@@ -37,11 +36,6 @@ if /i "%1"=="-p" (
     set publish=true
     goto :nextArg
 )
-if /i "%1"=="-t" (
-    set tfm=%2
-    shift
-    goto :nextArg
-)
 if /i "%1" == "-h" (
     goto :usage
 )
@@ -60,10 +54,10 @@ set projects=jit-diff jit-dasm jit-analyze jit-format cijobs pmi jit-dasm-pmi
 REM Build each project
 for %%p in (%projects%) do (
     if %publish%==true (
-        dotnet publish -c %buildType% -f %tfm% -o %appInstallDir% .\src\%%p
+        dotnet publish -c %buildType% -o %appInstallDir% .\src\%%p
         copy .\wrapper.bat %appInstallDir%\%%p.bat
     ) else (
-        dotnet build -c %buildType% -f %tfm% .\src\%%p
+        dotnet build -c %buildType% .\src\%%p
     )
 )
 
@@ -72,7 +66,7 @@ if %fx%==true (
     @REM for subsequent publish to be able to accept --runtime parameter to
     @REM publish it as standalone.
     dotnet restore --runtime %platform% .\src\packages
-    dotnet publish -c %buildType% -f %tfm% -o %fxInstallDir% --runtime %platform% .\src\packages
+    dotnet publish -c %buildType% -o %fxInstallDir% --runtime %platform% .\src\packages
     
     @REM remove package version of mscorlib* - refer to core root version for diff testing
     if exist %fxInstallDir%\mscorlib* del /q %fxInstallDir%\mscorlib*

--- a/build.sh
+++ b/build.sh
@@ -16,14 +16,12 @@ function usage
     echo "    -h              : Show this message."
     echo "    -f              : Install default framework directory in <script_root>/fx."
     echo "    -p              : Publish utilities."
-    echo "    -t <TARGET>     : Target framework. Default is netcoreapp2.1."
     echo ""
 }
 
 # defaults
 buildType="Release"
 publish=false
-tfm=netcoreapp2.1
 workingDir="$PWD"
 cd "`dirname \"$0\"`"
 scriptDir="$PWD"
@@ -49,9 +47,6 @@ while getopts "hpfbt:" opt; do
     f)  
         fx=true
         ;;
-    t)
-        tfm=$OPTARG
-        ;;
     esac
 done
 
@@ -62,10 +57,10 @@ declare -a projects=(jit-dasm jit-diff jit-analyze jit-format cijobs pmi jit-das
 for proj in "${projects[@]}"
 do
     if [ "$publish" == true ]; then
-        dotnet publish -c $buildType -f $tfm -o $appInstallDir ./src/$proj
+        dotnet publish -c $buildType -o $appInstallDir ./src/$proj
         cp ./wrapper.sh $appInstallDir/$proj
     else
-        dotnet build -c $buildType -f $tfm ./src/$proj
+        dotnet build -c $buildType ./src/$proj
     fi
 done
 

--- a/jitutils.sln
+++ b/jitutils.sln
@@ -5,21 +5,21 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{69D45FDC-948D-464B-BF14-5675F291FC62}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cijobs", "src\cijobs\cijobs.csproj", "{5B781D3D-308C-4415-8C68-17D557B143B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cijobs", "src\cijobs\cijobs.csproj", "{5B781D3D-308C-4415-8C68-17D557B143B8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jit-analyze", "src\jit-analyze\jit-analyze.csproj", "{BE601D81-9650-4755-84F8-F9BA57284C9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jit-analyze", "src\jit-analyze\jit-analyze.csproj", "{BE601D81-9650-4755-84F8-F9BA57284C9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jit-dasm", "src\jit-dasm\jit-dasm.csproj", "{C4C9F6AA-A360-4B27-A8E8-AB55FC383614}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jit-dasm", "src\jit-dasm\jit-dasm.csproj", "{C4C9F6AA-A360-4B27-A8E8-AB55FC383614}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jit-diff", "src\jit-diff\jit-diff.csproj", "{928320EE-2058-446D-A46E-6C795BBE7C68}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jit-diff", "src\jit-diff\jit-diff.csproj", "{928320EE-2058-446D-A46E-6C795BBE7C68}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jit-format", "src\jit-format\jit-format.csproj", "{37E93DAF-2993-4DF0-9E82-06817A3B7956}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jit-format", "src\jit-format\jit-format.csproj", "{37E93DAF-2993-4DF0-9E82-06817A3B7956}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "packages", "src\packages\packages.csproj", "{19436C6B-39C9-4A88-8021-3242D098637E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "packages", "src\packages\packages.csproj", "{19436C6B-39C9-4A88-8021-3242D098637E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pmi", "src\pmi\pmi.csproj", "{829E459B-EE3D-46A9-AD4D-4F2B03D5188C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "pmi", "src\pmi\pmi.csproj", "{829E459B-EE3D-46A9-AD4D-4F2B03D5188C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jit-dasm-pmi", "src\jit-dasm-pmi\jit-dasm-pmi.csproj", "{2C846294-79D4-40EA-8ED3-0F01E033BE32}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jit-dasm-pmi", "src\jit-dasm-pmi\jit-dasm-pmi.csproj", "{2C846294-79D4-40EA-8ED3-0F01E033BE32}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/cijobs/cijobs.csproj
+++ b/src/cijobs/cijobs.csproj
@@ -2,16 +2,27 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 

--- a/src/cijobs/cijobs.csproj
+++ b/src/cijobs/cijobs.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/cijobs/cijobs.csproj
+++ b/src/cijobs/cijobs.csproj
@@ -1,29 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="runtime.native.System" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/cijobs/cijobs.csproj
+++ b/src/cijobs/cijobs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(jit-include.props))" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/common.props
+++ b/src/common.props
@@ -1,0 +1,28 @@
+<Project>
+  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
+    <_UseNetCoreApp3>true</_UseNetCoreApp3>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
+	<TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>   
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+  </ItemGroup>
+
+</Project>

--- a/src/jit-analyze/jit-analyze.csproj
+++ b/src/jit-analyze/jit-analyze.csproj
@@ -2,16 +2,27 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 

--- a/src/jit-analyze/jit-analyze.csproj
+++ b/src/jit-analyze/jit-analyze.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-analyze/jit-analyze.csproj
+++ b/src/jit-analyze/jit-analyze.csproj
@@ -1,29 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="runtime.native.System" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-analyze/jit-analyze.csproj
+++ b/src/jit-analyze/jit-analyze.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(jit-include.props))" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-dasm-pmi/jit-dasm-pmi.csproj
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-dasm-pmi/jit-dasm-pmi.csproj
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.csproj
@@ -1,29 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="runtime.native.System" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-dasm-pmi/jit-dasm-pmi.csproj
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.csproj
@@ -2,17 +2,28 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-dasm-pmi/jit-dasm-pmi.csproj
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(jit-include.props))" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-dasm/jit-dasm.csproj
+++ b/src/jit-dasm/jit-dasm.csproj
@@ -2,16 +2,27 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 

--- a/src/jit-dasm/jit-dasm.csproj
+++ b/src/jit-dasm/jit-dasm.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-dasm/jit-dasm.csproj
+++ b/src/jit-dasm/jit-dasm.csproj
@@ -1,29 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="runtime.native.System" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-dasm/jit-dasm.csproj
+++ b/src/jit-dasm/jit-dasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(jit-include.props))" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-diff/jit-diff.csproj
+++ b/src/jit-diff/jit-diff.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(jit-include.props))" />
 
 
   <PropertyGroup>

--- a/src/jit-diff/jit-diff.csproj
+++ b/src/jit-diff/jit-diff.csproj
@@ -1,29 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="runtime.native.System" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-diff/jit-diff.csproj
+++ b/src/jit-diff/jit-diff.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-diff/jit-diff.csproj
+++ b/src/jit-diff/jit-diff.csproj
@@ -2,18 +2,28 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" Condition=" '$(TargetFramework)' == 'netcoreapp1.0' " />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-format/jit-format.csproj
+++ b/src/jit-format/jit-format.csproj
@@ -2,16 +2,27 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 

--- a/src/jit-format/jit-format.csproj
+++ b/src/jit-format/jit-format.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(jit-include.props))" />
 
 
   <PropertyGroup>

--- a/src/jit-format/jit-format.csproj
+++ b/src/jit-format/jit-format.csproj
@@ -1,29 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\util\util.cs" Link="util.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="runtime.native.System" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-format/jit-format.csproj
+++ b/src/jit-format/jit-format.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), common.props))\common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), jit-include.props))\jit-include.props" />
+
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/jit-include.props
+++ b/src/jit-include.props
@@ -1,12 +1,4 @@
 <Project>
-  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
-    <_UseNetCoreApp3>true</_UseNetCoreApp3>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
-	<TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>   
-  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />

--- a/src/packages/packages.csproj
+++ b/src/packages/packages.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/packages/packages.csproj
+++ b/src/packages/packages.csproj
@@ -4,6 +4,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
 
 </Project>

--- a/src/packages/packages.csproj
+++ b/src/packages/packages.csproj
@@ -4,13 +4,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
-    <_UseNetCoreApp3>true</_UseNetCoreApp3>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
 
 </Project>

--- a/src/packages/packages.csproj
+++ b/src/packages/packages.csproj
@@ -2,7 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
+    <_UseNetCoreApp3>true</_UseNetCoreApp3>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/pmi/pmi.csproj
+++ b/src/pmi/pmi.csproj
@@ -4,14 +4,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
-    <_UseNetCoreApp3>true</_UseNetCoreApp3>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
 
   <ItemGroup>
     <PackageReference Include="System.Management" Version="4.5.0" />

--- a/src/pmi/pmi.csproj
+++ b/src/pmi/pmi.csproj
@@ -2,11 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <Optimize>false</Optimize>
+  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
+    <_UseNetCoreApp3>true</_UseNetCoreApp3>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/pmi/pmi.csproj
+++ b/src/pmi/pmi.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), target-framework.props))\target-framework.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
 
   <ItemGroup>
     <PackageReference Include="System.Management" Version="4.5.0" />

--- a/src/pmi/pmi.csproj
+++ b/src/pmi/pmi.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/target-framework.props
+++ b/src/target-framework.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
+    <_UseNetCoreApp3>true</_UseNetCoreApp3>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
+	<TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>   
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This change is based on #181 and adds these commits:

18d9a56: Use netcoreapp3.0 if available.

Allows to run [dotnet/performanc](https://github.com/dotnet/performancee) and arm64 (they both require 3.0 to be installed).

13050c6: Force the new project system for *.cs projects.

Otherwise it does not see `TargetFramework` from the props file and uses the old one that doesn't show *.cs files in VS (because that are not included by default in the old version), but it also doesn't allow to include them because then you will hit build errors (one file is included twice).
See the issue description dotnet/project-system#1358 and the workaround is at the end of the thread.

e5f39ab: Separate common.props into two files.

One defines `<TargetFramework>`, the other `<PackageReference Include>`.
This change allows you to switch to another version (2.2 for example) simply by editing target-framework.props.

b735eb6: Delete `Target framework` argument for build.cmd/sh.

We do use `<TargetFrameworks>` anymore and there is no need to choose tfm from these scripts.

After that changes you can run jitutils on a machine with only 2.1 installed or on a machine that has only 3.0. Also, it works correctly when you open the solution in VS.

The last step in the build process doesn't pass on 3.0 because of dotnet/core-setup#4884, but will work once that is fixed.

Contributes to #186.