### PR TITLE
Fix some ifdefs so pmi works with 3.0

### DIFF
--- a/src/pmi/PMIDriver.cs
+++ b/src/pmi/PMIDriver.cs
@@ -167,7 +167,7 @@ namespace PMIDriver
                 p.StartInfo.RedirectStandardError = true;
 
                 // Fetch our command line. Split off the arguments.
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0
                 // For .Net Core the PMI assembly is an argument to dotnet.
                 string newCommandLine = Environment.CommandLine.Replace("DRIVEALL", "PREPALL");
 #else

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -1164,8 +1164,6 @@ class PrepareMethodinator
             return Usage();
         }
 
-
-
         // Tracing infrastructure unconditionally creates a Timer and uses it for checking
         // whether tracing has been enabled. Since the Timer callback is called on a worker thread,
         // we may get corrupted disasm output. To prevent that, force jitting of Timer callback infrastructure
@@ -1259,7 +1257,7 @@ class PrepareMethodinator
         int result = 0;
         string msg = "a file";
 
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0
         msg += " or a directory";
         if (Directory.Exists(assemblyName))
         {


### PR DESCRIPTION
NETCOREAPP2_1 does not imply NETCOREAPP3_0. We can clean all this up
once NETSTANDARD2_1 becomes a thing.