### PR TITLE
jit-dasm-pmi: set PMIPATH properly

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -528,7 +528,7 @@ namespace ManagedCodeGen
                     }
 
                     // Set up PMI path...
-                    AddEnvironmentVariable("PMIPATH", Path.GetDirectoryName(assembly.Name));
+                    AddEnvironmentVariable("PMIPATH", assembly.Path);
 
                     if (this.verbose)
                     {


### PR DESCRIPTION
Currently PMIPATH is always set to an empty string. It should be set to the
directory of the target assembly.

Closes #201.