### PR TITLE
Have jit-format explicitly specify that it needs a compile_commands.json from the CMake configuration

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -250,7 +250,7 @@ namespace ManagedCodeGen
                         if (!File.Exists(Path.Combine(compileCommandsPath)))
                         {
                             Console.WriteLine("Can't find compile_commands.json file. Running configure.");
-                            string[] commandArgs = { _arch, _build, "configureonly" };
+                            string[] commandArgs = { _arch, _build, "configureonly", "-cmakeargs", "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" };
                             string buildPath = Path.Combine(_rootPath, "build.sh");
                             CommandResult result = Utility.TryCommand(buildPath, commandArgs, true, _rootPath);
 


### PR DESCRIPTION

Right now the fact that jit-format needs a compile_commands.json file isn't explicit anywhere in CoreCLR and nowhere in CoreCLR uses the compilation database. This change makes jit-format explicitly request the compile_commands.json on Unix systems where there is a `-cmakeargs` parameter to our build scripts.

There's no comparable flag on our Windows build scripts, so there's not a good way to move that knowledge into jit-format. As a result, I'm planning a PR into CoreCLR that will only tell CMake to generate a compile_commands.json when the `usenmakemakefiles` parameter is passed (which makes sense because the only reason to use the NMake generator is to generate a compile_commands.json file since the VS generators don't support generating a compile_commands.json).