### PR TITLE
Update PMI to use the new System.CommandLine parser

### DIFF
--- a/src/cijobs/cijobs.cs
+++ b/src/cijobs/cijobs.cs
@@ -33,22 +33,14 @@ using System.CommandLine;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.IO.Compression;
-//using Microsoft.DotNet.Cli.Utils;
-//using Microsoft.DotNet.Tools.Common;
 using Newtonsoft.Json;
-//using Newtonsoft.Json.Linq;
+using System.CommandLine.Invocation;
 
 namespace ManagedCodeGen
 {
+    using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
     internal class cijobs
     {
-        // Supported commands.  List to view information from the CI system, and Copy to download artifacts.
-        public enum Command
-        {
-            List,
-            Copy
-        }
-        
         // List options control what level and level of detail to put out.
         // Jobs lists jobs under a product.
         // Builds lists build instances under a job.
@@ -63,184 +55,113 @@ namespace ManagedCodeGen
         // Define options to be parsed 
         public class Config
         {
-            private ArgumentSyntax _syntaxResult;
-            private Command _command = Command.List;
-            private ListOption _listOption = ListOption.Invalid;
-            private string _server = "http://ci.dot.net/";
-            private string _jobName;
-            private string _contentPath;
-            private string _repoName = "dotnet_coreclr";
-            private int _number = 0;
-            private string _matchPattern = String.Empty;
-            private string _branchName = "master";
-            private bool _lastSuccessful = false;
-            private string _commit;
-            private bool _unzip = false;
-            private string _outputPath;
-            private string _outputRoot;
-            private bool _artifacts = false;
-
-            public Config(string[] args)
+            public void ValidateCopy()
             {
-                _syntaxResult = ArgumentSyntax.Parse(args, syntax =>
+                if (!Uri.IsWellFormedUriString(Server, UriKind.Absolute))
                 {
-                    // NOTE!!! - Commands and their options are ordered.  Moving an option out of line
-                    // could move it to another command.  Take a careful look at how they're organized
-                    // before changing.
-                    syntax.DefineCommand("list", ref _command, Command.List, 
-                        "List jobs on dotnet-ci.cloudapp.net for the repo.");
-                    syntax.DefineOption("s|server", ref _server, "Url of the server. Defaults to http://ci.dot.net/");
-                    syntax.DefineOption("j|job", ref _jobName, "Name of the job.");
-                    syntax.DefineOption("b|branch", ref _branchName, 
-                        "Name of the branch (default is master).");
-                    syntax.DefineOption("r|repo", ref _repoName, 
-                        "Name of the repo (e.g. dotnet_corefx or dotnet_coreclr). Default is dotnet_coreclr.");
-                    syntax.DefineOption("m|match", ref _matchPattern, 
-                        "Regex pattern used to select jobs output.");
-                    syntax.DefineOption("n|number", ref _number, "Job number.");
-                    syntax.DefineOption("l|last_successful", ref _lastSuccessful, 
-                        "List last successful build.");
-                    syntax.DefineOption("c|commit", ref _commit, "List build at this commit.");
-                    syntax.DefineOption("a|artifacts", ref _artifacts, "List job artifacts on server.");
-
-                    syntax.DefineCommand("copy", ref _command, Command.Copy, 
-                        "Copies job artifacts from dotnet-ci.cloudapp.net. " 
-                        + "This command copies a zip of artifacts from a repo (defaulted to dotnet_coreclr)." 
-                        + " The default location of the zips is the Product sub-directory, though "
-                        + "that can be changed using the ContentPath(p) parameter");
-                    syntax.DefineOption("s|server", ref _server, "Url of the server. Defaults to http://ci.dot.net/");
-                    syntax.DefineOption("j|job", ref _jobName, "Name of the job.");
-                    syntax.DefineOption("n|number", ref _number, "Job number.");
-                    syntax.DefineOption("l|last_successful", ref _lastSuccessful, 
-                        "Copy last successful build.");
-                    syntax.DefineOption("c|commit", ref _commit, "Copy this commit.");
-                    syntax.DefineOption("b|branch", ref _branchName, 
-                        "Name of the branch (default is master).");
-                    syntax.DefineOption("r|repo", ref _repoName, 
-                        "Name of the repo (e.g. dotnet_corefx or dotnet_coreclr). Default is dotnet_coreclr.");
-                    syntax.DefineOption("o|output", ref _outputPath, "The path where output will be placed.");
-                    syntax.DefineOption("or|output_root", ref _outputRoot,
-                        "The root directory where output will be placed. A subdirectory named by job and build number will be created within this to store the output.");
-                    syntax.DefineOption("u|unzip", ref _unzip, "Unzip copied artifacts");
-                    syntax.DefineOption("p|ContentPath", ref _contentPath,
-                        "Relative product zip path. Default is artifact/bin/Product/*zip*/Product.zip");
-                });
-
-                // Run validation code on parsed input to ensure we have a sensible scenario.
-                validate();
-            }
-
-            private void validate()
-            {
-                if (!Uri.IsWellFormedUriString(_server, UriKind.Absolute))
-                {
-                    _syntaxResult.ReportError($"Invalid uri: {_server}.");
+                    ReportError($"Invalid uri: {Server}.");
                 }
-                switch (_command)
-                {
-                    case Command.List:
-                        {
-                            validateList();
-                        }
-                        break;
-                    case Command.Copy:
-                        {
-                            validateCopy();
-                        }
-                        break;
-                }
-            }
 
-            private void validateCopy()
-            {
-                if (_jobName == null) 
+                if (Job == null) 
                 {
-                    _syntaxResult.ReportError("Must have --job <name> for copy.");
+                    ReportError("Must have --job <name> for copy.");
                 }
                 
-                if (_number == 0 && !_lastSuccessful && _commit == null)
+                if (Number == 0 && !LastSuccessful && Commit == null)
                 {
-                    _syntaxResult.ReportError("Must have --number <num>, --last_successful, or --commit <commit> for copy.");
+                    ReportError("Must have --number <num>, --last_successful, or --commit <commit> for copy.");
                 }
 
-                if (Convert.ToInt32(_number != 0) + Convert.ToInt32(_lastSuccessful) + Convert.ToInt32(_commit != null) > 1)
+                if (Convert.ToInt32(Number != 0) + Convert.ToInt32(LastSuccessful) + Convert.ToInt32(Commit != null) > 1)
                 {
-                    _syntaxResult.ReportError("Must have only one of --number <num>, --last_successful, and --commit <commit> for copy.");
+                    ReportError("Must have only one of --number <num>, --last_successful, and --commit <commit> for copy.");
                 }
 
-                if ((_outputPath == null) && (_outputRoot == null))
+                if ((OutputPath == null) && (OutputRoot == null))
                 {
-                    _syntaxResult.ReportError("Must specify either --output <path> or --output_root <path> for copy.");
+                    ReportError("Must specify either --output <path> or --output_root <path> for copy.");
                 }
 
-                if ((_outputPath != null) && (_outputRoot != null))
+                if ((OutputPath != null) && (OutputRoot != null))
                 {
-                    _syntaxResult.ReportError("Must specify only one of --output <path> or --output_root <path>.");
+                    ReportError("Must specify only one of --output <path> or --output_root <path>.");
                 }
 
-                if (_contentPath == null)
+                if (ContentPath == null)
                 {
-                    _contentPath = "artifact/bin/Product/*zip*/Product.zip";
+                    ContentPath = "artifact/bin/Product/*zip*/Product.zip";
                 }
             }
 
-            private void validateList()
+            public void ValidateList()
             {
-                if (_jobName != null)
+                if (!Uri.IsWellFormedUriString(Server, UriKind.Absolute))
                 {
-                    _listOption = ListOption.Builds;
+                    ReportError($"Invalid uri: {Server}.");
+                }
 
-                    if (Convert.ToInt32(_number != 0) + Convert.ToInt32(_lastSuccessful) + Convert.ToInt32(_commit != null) > 1)
+                if (Job != null)
+                {
+                    DoListOption = ListOption.Builds;
+
+                    if (Convert.ToInt32(Number != 0) + Convert.ToInt32(LastSuccessful) + Convert.ToInt32(Commit != null) > 1)
                     {
-                        _syntaxResult.ReportError("Must have at most one of --number <num>, --last_successful, and --commit <commit> for list.");
+                        ReportError("Must have at most one of --number <num>, --last_successful, and --commit <commit> for list.");
                     }
 
-                    if (_matchPattern != String.Empty)
+                    if (Match != String.Empty)
                     {
-                        _syntaxResult.ReportError("Match pattern not valid with --job");
+                        ReportError("Match pattern not valid with --job");
                     }
                 }
                 else
                 {
-                    _listOption = ListOption.Jobs;
+                    DoListOption = ListOption.Jobs;
 
-                    if (_number != 0)
+                    if (Number != 0)
                     {
-                        _syntaxResult.ReportError("Must select --job <name> to specify --number <num>.");
+                        ReportError("Must select --job <name> to specify --number <num>.");
                     }
 
-                    if (_lastSuccessful)
+                    if (LastSuccessful)
                     {
-                        _syntaxResult.ReportError("Must select --job <name> to specify --last_successful.");
+                        ReportError("Must select --job <name> to specify --last_successful.");
                     }
 
-                    if (_commit != null)
+                    if (Commit != null)
                     {
-                        _syntaxResult.ReportError("Must select --job <name> to specify --commit <commit>.");
+                        ReportError("Must select --job <name> to specify --commit <commit>.");
                     }
 
-                    if (_artifacts)
+                    if (Artifacts)
                     {
-                        _syntaxResult.ReportError("Must select --job <name> to specify --artifacts.");
+                        ReportError("Must select --job <name> to specify --artifacts.");
                     }
                 }
             }
 
-            public Command DoCommand { get { return _command; } }
-            public ListOption DoListOption { get { return _listOption; } }
-            public string JobName { get { return _jobName; } }
-            public string Server { get { return _server; } }
-            public string ContentPath { get { return _contentPath; } }
-            public int Number { get { return _number; } set { this._number = value; } }
-            public string MatchPattern { get { return _matchPattern; } }
-            public string BranchName { get { return _branchName; } }
-            public string RepoName { get { return _repoName; } }
-            public bool LastSuccessful { get { return _lastSuccessful; } }
-            public string Commit { get { return _commit; } }
-            public bool DoUnzip { get { return _unzip; } }
-            public string OutputPath { get { return _outputPath; } }
-            public string OutputRoot { get { return _outputRoot; } }
-            public bool Artifacts { get { return _artifacts; } }
+            void ReportError(string message)
+            {
+                Console.WriteLine(message);
+                Error = true;
+            }
+
+            public Command DoCommand { get; set; }
+            public ListOption DoListOption { get; set; }
+            public string Job { get; set; }
+            public string Server { get; set; }
+            public string ContentPath { get; set; }
+            public int Number { get; set; }
+            public string Match { get; set; }
+            public string Branch { get; set; }
+            public string Repo { get; set; }
+            public bool LastSuccessful { get; set; }
+            public string Commit { get; set; }
+            public bool DoUnzip { get; set; }
+            public string OutputPath { get; set; }
+            public string OutputRoot { get; set; }
+            public bool Artifacts { get; set; }
+            public bool Error { get; set; }
         }
 
         // The following block of simple structs maps to the data extracted from the CI system as json.
@@ -302,33 +223,118 @@ namespace ManagedCodeGen
         // and switch on the command to invoke underlying logic.
         private static int Main(string[] args)
         {
-            Config config = new Config(args);
-            int error = 0;
-
-            CIClient cic = new CIClient(config);
-
-            Command currentCommand = config.DoCommand;
-            switch (currentCommand)
+            Command listCommand = new Command("list");
             {
-                case Command.List:
+                listCommand.Description = "List jobs on dotnet-ci.cloudapp.net for the repo.";
+
+                Option serverOption = new Option("--server", "Url of the server. Defaults to http://ci.dot.net/", new Argument<string>("http://ci.dot.net/"));
+                serverOption.AddAlias("-s");
+                Option jobOption = new Option("--job", "Name of the job.", new Argument<string>());
+                jobOption.AddAlias("-j");
+                Option branchOption = new Option("--branch", "Name of the branch (default is master).", new Argument<string>("master"));
+                branchOption.AddAlias("-b");
+                Option repoOption = new Option("--repo", "Name of the repo(e.g.dotnet_corefx or dotnet_coreclr). Default is dotnet_coreclr.", new Argument<string>("dotnet_coreclr"));
+                repoOption.AddAlias("-r");
+                Option matchOption = new Option("--match", "Regex pattern used to select jobs output.", new Argument<string>(String.Empty));
+                matchOption.AddAlias("-m");
+                Option numberOption = new Option("--number", "Job number.", new Argument<int>());
+                numberOption.AddAlias("-n");
+                Option lastOption = new Option("--last-successful", "List last successful build.", new Argument<bool>());
+                lastOption.AddAlias("-l");
+                Option commitOption = new Option("--commit", "List build at this commit.", new Argument<string>());
+                commitOption.AddAlias("-c");
+                Option artifactsOption = new Option("--artifacts", "List job artifacts on server.", new Argument<bool>());
+                artifactsOption.AddAlias("-a");
+
+                listCommand.AddOption(serverOption);
+                listCommand.AddOption(jobOption);
+                listCommand.AddOption(branchOption);
+                listCommand.AddOption(repoOption);
+                listCommand.AddOption(matchOption);
+                listCommand.AddOption(numberOption);
+                listCommand.AddOption(lastOption);
+                listCommand.AddOption(commitOption);
+                listCommand.AddOption(artifactsOption);
+
+                listCommand.Handler = CommandHandler.Create<Config>((config) =>
+                {
+                    config.ValidateList();
+
+                    if (config.Error)
                     {
-                        ListCommand.List(cic, config).Wait();
-                        break;
+                        return -1;
                     }
-                case Command.Copy:
-                    {
-                        CopyCommand.Copy(cic, config).Wait();
-                        break;
-                    }
-                default:
-                    {
-                        Console.Error.WriteLine("super bad!  why no command!");
-                        error = 1;
-                        break;
-                    }
+
+                    CIClient cic = new CIClient(config);
+                    ListCommand.List(cic, config).Wait();
+
+                    return 0;
+                });
             }
 
-            return error;
+            Command copyCommand = new Command("copy");
+            {
+                copyCommand.Description = "Copies job artifacts from dotnet-ci.cloudapp.net. "
+                    + "This command copies a zip of artifacts from a repo (defaulted to dotnet_coreclr). "
+                    + "The default location of the zips is the Product sub-directory, though "
+                    + "that can be changed using the ContentPath(p) parameter";
+
+                Option serverOption = new Option("--server", "Url of the server. Defaults to http://ci.dot.net/", new Argument<string>("http://ci.dot.net/"));
+                serverOption.AddAlias("-s");
+                Option jobOption = new Option("--job", "Name of the job.", new Argument<string>());
+                jobOption.AddAlias("-j");
+                Option branchOption = new Option("--branch", "Name of the branch (default is master).", new Argument<string>("master"));
+                branchOption.AddAlias("-b");
+                Option repoOption = new Option("--repo", "Name of the repo(e.g.dotnet_corefx or dotnet_coreclr). Default is dotnet_coreclr.", new Argument<string>("dotnet_coreclr"));
+                repoOption.AddAlias("-r");
+                Option numberOption = new Option("--number", "Job number.", new Argument<int>());
+                numberOption.AddAlias("-n");
+                Option lastOption = new Option("--last-successful", "List last successful build.", new Argument<bool>());
+                lastOption.AddAlias("-l");
+                Option commitOption = new Option("--commit", "List build at this commit.", new Argument<string>());
+                commitOption.AddAlias("-c");
+                Option outputOption = new Option("--output", "The path where output will be placed.", new Argument<string>());
+                outputOption.AddAlias("-o");
+                Option outputRootOption = new Option("--output-root", "The root directory where output will be placed. A subdirectory named by job and build number will be created within this to store the output.", new Argument<string>());
+                outputRootOption.AddAlias("-or");
+                Option unzipOption = new Option("--unzip", "Unzip copied artifacts", new Argument<bool>());
+                unzipOption.AddAlias("-u");
+                Option contentOption = new Option("--content-path", "Relative product zip path. Default is artifact/bin/Product/*zip*/Product.zip", new Argument<string>());
+                contentOption.AddAlias("-p");
+
+                copyCommand.AddOption(serverOption);
+                copyCommand.AddOption(jobOption);
+                copyCommand.AddOption(branchOption);
+                copyCommand.AddOption(repoOption);
+                copyCommand.AddOption(numberOption);
+                copyCommand.AddOption(lastOption);
+                copyCommand.AddOption(commitOption);
+                copyCommand.AddOption(outputOption);
+                copyCommand.AddOption(outputRootOption);
+                copyCommand.AddOption(unzipOption);
+                copyCommand.AddOption(contentOption);
+
+                copyCommand.Handler = CommandHandler.Create<Config>((config) =>
+                {
+                    config.ValidateCopy();
+
+                    if (config.Error)
+                    {
+                        return -1;
+                    }
+
+                    CIClient cic = new CIClient(config);
+                    CopyCommand.Copy(cic, config).Wait();
+
+                    return 0;
+                });
+            }
+
+            RootCommand rootCommand = new RootCommand();
+            rootCommand.AddCommand(copyCommand);
+            rootCommand.AddCommand(listCommand);
+
+            return rootCommand.InvokeAsync(args).Result;
         }
 
         // Wrap CI httpClient with focused APIs for product, job, and build.
@@ -350,7 +356,7 @@ namespace ManagedCodeGen
             {
                 string messageString
                         = String.Format("job/{0}/job/{1}/job/{2}/{3}/{4}",
-                            config.RepoName, config.BranchName, config.JobName, config.Number, contentPath);
+                            config.Repo, config.Branch, config.Job, config.Number, contentPath);
 
                  Console.WriteLine("Downloading: {0}", messageString);
 
@@ -521,11 +527,11 @@ namespace ManagedCodeGen
                 {
                     case ListOption.Jobs:
                         {
-                            var jobs = await cic.GetProductJobs(config.RepoName, config.BranchName);
+                            var jobs = await cic.GetProductJobs(config.Repo, config.Branch);
 
-                            if (config.MatchPattern != null)
+                            if (config.Match != null)
                             {
-                                var pattern = new Regex(config.MatchPattern);
+                                var pattern = new Regex(config.Match);
                                 PrettyJobs(jobs.Where(x => pattern.IsMatch(x.name)));
                             }
                             else
@@ -536,8 +542,8 @@ namespace ManagedCodeGen
                         break;
                     case ListOption.Builds:
                         {
-                            var builds = await cic.GetJobBuilds(config.RepoName, config.BranchName,
-                                                                config.JobName, config.LastSuccessful,
+                            var builds = await cic.GetJobBuilds(config.Repo, config.Branch,
+                                                                config.Job, config.LastSuccessful,
                                                                 config.Number, config.Commit);
 
                             if (config.LastSuccessful && builds.Any())
@@ -613,7 +619,7 @@ namespace ManagedCodeGen
                 if (config.LastSuccessful)
                 {
                     // Query last successful build and extract the number.
-                    var builds = await cic.GetJobBuilds(config.RepoName, config.BranchName, config.JobName, true, 0, null);
+                    var builds = await cic.GetJobBuilds(config.Repo, config.Branch, config.Job, true, 0, null);
                     
                     if (!builds.Any())
                     {
@@ -626,7 +632,7 @@ namespace ManagedCodeGen
                 }
                 else if (config.Commit != null)
                 {
-                    var builds = await cic.GetJobBuilds(config.RepoName, config.BranchName, config.JobName, false, 0, config.Commit);
+                    var builds = await cic.GetJobBuilds(config.Repo, config.Branch, config.Job, false, 0, config.Commit);
 
                     if (!builds.Any())
                     {
@@ -646,7 +652,7 @@ namespace ManagedCodeGen
                 }
                 else
                 {
-                    string tag = String.Format("{0}-{1}", config.JobName, config.Number);
+                    string tag = String.Format("{0}-{1}", config.Job, config.Number);
                     outputPath = Path.Combine(config.OutputRoot, tag);
                 }
 

--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -58,19 +58,19 @@ namespace ManagedCodeGen
             }
 
             // JitPath must be specified and exist.
-            if (JitPath == null)
+            if (Jit == null)
             {
                 ReportError("You must specify --jitPath.");
             }
-            else if (!File.Exists(JitPath))
+            else if (!File.Exists(Jit))
             {
                 ReportError("Can't find --jitPath library.");
             }
             else
             {
                 // Set to full path for command resolution logic.
-                string fullJitPath = Path.GetFullPath(JitPath);
-                JitPath = fullJitPath;
+                string fullJitPath = Path.GetFullPath(Jit);
+                Jit = fullJitPath;
             }
 
             if ((FileName == null) && (AssemblyList.Count == 0))
@@ -97,9 +97,10 @@ namespace ManagedCodeGen
         public bool NoCopy { get; set; }
         public bool CopyJit { get { return !NoCopy; } }
         public string Corerun { get; set; }
-        public string JitPath { get; set; }
+        public string Jit { get; set; }
         public string AltJit { get; set; }
-        public string RootPath { get; set; }
+        public string Output { get; set; }
+        public string RootPath { get { return Output; } }
         public IReadOnlyList<string> Platform { get; set; }
         public string FileName { get; set; }
         public IReadOnlyList<string> AssemblyList { get; set; }
@@ -127,8 +128,8 @@ namespace ManagedCodeGen
             Option altJitOption = new Option("--altjit", "If set, the name of the altjit to use (e.g., protononjit.dll).", new Argument<string>());
             Option corerunOption = new Option("--corerun", "Path to corerun.", new Argument<string>());
             corerunOption.AddAlias("-c");
-            Option jitPathOption = new Option("--jitPath", "The full path to the jit library.", new Argument<string>());
-            jitPathOption.AddAlias("-j");
+            Option jitOption = new Option("--jit", "The full path to the jit library.", new Argument<string>());
+            jitOption.AddAlias("-j");
             Option outputOption = new Option("--output", "The output path.", new Argument<string>());
             outputOption.AddAlias("-o");
             Option fileNameOption = new Option("--fileName", "Name of file to take list of assemblies from. Both a file and assembly list can be used.", new Argument<string>());
@@ -139,7 +140,7 @@ namespace ManagedCodeGen
             verboseOption.AddAlias("-v");
             Option recursiveOption = new Option("--recursive", "Scan directories recursively", new Argument<bool>());
             recursiveOption.AddAlias("-r");
-            Option platformOption = new Option("--platform", "Path to platform assemblies", new Argument<string>() { Arity = ArgumentArity.OneOrMore });
+            Option platformOption = new Option("--platform", "Path to platform assemblies", new Argument<string>() { Arity = ArgumentArity.ExactlyOne });
             platformOption.AddAlias("-p");
             Option tieringOption = new Option("--tiering", "Enable tiered jitting", new Argument<bool>());
             tieringOption.AddAlias("-t");
@@ -154,7 +155,7 @@ namespace ManagedCodeGen
 
             rootCommand.AddOption(altJitOption);
             rootCommand.AddOption(corerunOption);
-            rootCommand.AddOption(jitPathOption);
+            rootCommand.AddOption(jitOption);
             rootCommand.AddOption(outputOption);
             rootCommand.AddOption(fileNameOption);
             rootCommand.AddOption(gcInfoOption);
@@ -363,7 +364,7 @@ namespace ManagedCodeGen
                 _executablePath = executable;
                 _rootPath = outputPath;
                 _platformPaths = config.Platform;
-                _jitPath = config.JitPath;
+                _jitPath = config.Jit;
                 _altjit = config.AltJit;
                 _assemblyInfoList = assemblyInfoList;
 

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -7,11 +7,11 @@ using System.CommandLine;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.DotNet.Cli.Utils;
 using System.Threading.Tasks;
 
 namespace ManagedCodeGen
 {
+    using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
     using DasmWorkTask = Task<(DasmWorkKind kind, int errorCount)>;
 
     public enum DasmWorkKind

--- a/src/jit-diff/install.cs
+++ b/src/jit-diff/install.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.Cli.Utils;
 //using Microsoft.DotNet.Tools.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using CommandResult = Microsoft.DotNet.Cli.Utils.CommandResult;
 //using System.Collections.Concurrent;
 //using System.Threading.Tasks;
 //using System.Runtime.InteropServices;
@@ -44,7 +45,7 @@ namespace ManagedCodeGen
             // "--last_successful", in which case we don't know what the build number (and hence
             // tag) is.
             string tag = null;
-            if (!config.DoLastSucessful)
+            if (!config.LastSuccessful)
             {
                 tag = String.Format("{0}-{1}", config.JobName, config.Number);
                 if (tools.Where(x => (string)x["tag"] == tag).Any())
@@ -70,7 +71,7 @@ namespace ManagedCodeGen
                 cijobsArgs.Add(config.BranchName);
             }
 
-            if (config.DoLastSucessful)
+            if (config.LastSuccessful)
             {
                 cijobsArgs.Add("--last_successful");
             }
@@ -106,7 +107,7 @@ namespace ManagedCodeGen
             //
             // However, if we passed "--last_successful", we don't know that number! So, figure it out.
 
-            if (config.DoLastSucessful)
+            if (config.LastSuccessful)
             {
                 // Find the largest numbered build with this job name.
                 int maxBuildNum = -1;

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -37,6 +37,8 @@ namespace ManagedCodeGen
             private bool _rewriteCompileCommands = false;
             private JObject _jObj;
             private string _jitUtilsRoot = null;
+            private IReadOnlyList<string> _filenames = Array.Empty<string>();
+            private IReadOnlyList<string> _projects = Array.Empty<string>();
 
             void ReportError(string message)
             {
@@ -334,8 +336,16 @@ namespace ManagedCodeGen
             public string OS { get; set; }
             public string Build { get; set; }
             public string CompileCommands { get; set; }
-            public IReadOnlyList<string> Filenames { get; set; }
-            public IReadOnlyList<string> Projects { get; set; }
+            public IReadOnlyList<string> Filenames
+            {
+                get { return _filenames; }
+                set { _filenames = value; }
+            }
+            public IReadOnlyList<string> Projects
+            {
+                get { return _projects.Count == 0 ? new List<string> { "dll" } : _projects; }
+                set { _projects = value; }
+            }
             public string SourceDirectory { get; set; }
             public bool Error { get; set; }
         }
@@ -378,7 +388,7 @@ namespace ManagedCodeGen
             Option projectsOption = new Option("--projects", "List of build projects clang-tidy should consider (e.g. dll, standalone, protojit, etc.). Default: dll", 
                 new Argument<string>() { Arity = ArgumentArity.OneOrMore });
 
-            Argument fileNameList = new Argument<string>() { Arity = ArgumentArity.OneOrMore };
+            Argument fileNameList = new Argument<string>() { Arity = ArgumentArity.ZeroOrMore };
             fileNameList.Name = "filenames";
             fileNameList.Description = "Optional list of files that should be formatted.";
 

--- a/src/jit-include.props
+++ b/src/jit-include.props
@@ -9,12 +9,12 @@
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
     <PackageReference Include="runtime.native.System" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19272.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19272.1" />
   </ItemGroup>
 
 </Project>

--- a/src/pmi/PMIDriver.cs
+++ b/src/pmi/PMIDriver.cs
@@ -166,16 +166,17 @@ namespace PMIDriver
                 p.StartInfo.RedirectStandardOutput = true;
                 p.StartInfo.RedirectStandardError = true;
 
-                // Fetch our command line. Split off the arguments.
+                // Fetch our command line, and fix up the arguments.
+
+                string newArgs = $"PREPALL --method {pi.methodToPrep}";
 #if NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0
                 // For .Net Core the PMI assembly is an argument to dotnet.
-                string newCommandLine = Environment.CommandLine.Replace("DRIVEALL", "PREPALL");
+                string newCommandLine = Environment.CommandLine.Replace("DRIVEALL", newArgs);
 #else
                 // For .Net Framework the OS knows how to bootstrap .Net when
                 // passed the PMI assembly as an executable.
-                string newCommandLine = "PREPALL \"" + pi.assemblyName + "\"";
+                string newCommandLine = newArgs + " \"" + pi.assemblyName + "\"";
 #endif
-                newCommandLine += " " + pi.methodToPrep;
 
                 Process thisProcess = Process.GetCurrentProcess();
                 string driverName = thisProcess.MainModule.FileName;

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -1328,6 +1328,7 @@ class PrepareMethodinator
         Command countCommand = new Command("COUNT");
         {
             countCommand.Description = "Count the number of types and methods in an assembly.";
+            countCommand.AddAlias("count");
 
             Argument<string> assemblyArgument = new Argument<string>();
             assemblyArgument.Arity = ArgumentArity.ExactlyOne;
@@ -1354,6 +1355,7 @@ class PrepareMethodinator
         Command prepallCommand = new Command("PREPALL");
         {
             prepallCommand.Description = "JIT all the methods in an assembly or all assemblies in a directory tree.";
+            prepallCommand.AddAlias("prepall");
 
             Argument<string> assemblyArgument = new Argument<string>();
             assemblyArgument.Arity = ArgumentArity.ExactlyOne;
@@ -1402,6 +1404,7 @@ class PrepareMethodinator
         Command preponeCommand = new Command("PREPONE");
         {
             preponeCommand.Description = "JIT exactly one method in an assembly.";
+            preponeCommand.AddAlias("prepone");
 
             Argument<string> assemblyArgument = new Argument<string>();
             assemblyArgument.Arity = ArgumentArity.ExactlyOne;
@@ -1436,6 +1439,7 @@ class PrepareMethodinator
         Command driveallCommand = new Command("DRIVEALL");
         {
             driveallCommand.Description = "JIT all the methods in an assembly robustly, skipping methods with asserts.";
+            driveallCommand.AddAlias("driveall");
 
             Argument<string> assemblyArgument = new Argument<string>();
             assemblyArgument.Arity = ArgumentArity.ExactlyOne;
@@ -1443,6 +1447,8 @@ class PrepareMethodinator
             assemblyArgument.Description = "Assembly file to process";
             driveallCommand.AddArgument(assemblyArgument);
 
+            // Thse options are ignored by the handler -- DRIVEALL will grab the command line for child invocations of PREPALL.
+            // But by including them here we validate them early.
             Option cctorOption = new Option("--cctors", "Try and invoke cctors first", new Argument<bool>());
             Option quietOption = new Option("--quiet", "Don't show progress messages", new Argument<bool>());
             Option timeOption = new Option("--time", "Show elapsed time information", new Argument<bool>());
@@ -1450,9 +1456,7 @@ class PrepareMethodinator
             driveallCommand.AddOption(quietOption);
             driveallCommand.AddOption(timeOption);
 
-            // Options are ignored here, as DRIVEALL will grab the command line for child invocations of PREPALL.
-            // By including them here we validate them early.
-            driveallCommand.Handler = CommandHandler.Create<string, bool, bool, bool>((assemblyName, cctors, quiet, time) =>
+            driveallCommand.Handler = CommandHandler.Create<string>((assemblyName) =>
             {
                 if (File.Exists(assemblyName))
                 {

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -625,7 +627,7 @@ class PrepareOne : PrepareBase
             {
                 Console.WriteLine($"PREPONE type# {typeCount} method# {methodCount} {type.FullName}::{method.Name}");
                 TimeSpan elapsedFunc = PrepareMethod(type, method);
-                Console.WriteLine($"Completed method {type.FullName}::{method.Name}");
+                Console.Write($"Completed method {type.FullName}::{method.Name}");
                 if (elapsedFunc != TimeSpan.MinValue)
                 {
                     Console.WriteLine($", elapsed ms: {elapsedFunc.TotalMilliseconds:F2}");
@@ -973,10 +975,11 @@ class Worker
                 {
                     visitor.StartMethod(type, methodBase);
                     keepGoing = visitor.FinishMethod(type, methodBase);
-                    if (!keepGoing)
-                    {
-                        break;
-                    }
+                }
+
+                if (!keepGoing)
+                {
+                    break;
                 }
             }
         }
@@ -1315,121 +1318,160 @@ class PrepareMethodinator
     // >= 100 - failure
     public static int Main(string[] args)
     {
-        if (args.Length < 2)
-        {
-            return Usage();
-        }
-
         // Tracing infrastructure unconditionally creates a Timer and uses it for checking
         // whether tracing has been enabled. Since the Timer callback is called on a worker thread,
         // we may get corrupted disasm output. To prevent that, force jitting of Timer callback infrastructure
         // before we PMI any method.
         EnsureTimerCallbackIsJitted();
 
-        string command = args[0].ToUpper();
-        string assemblyName = args[1];
-        int methodToPrep = -1; // For PREPONE, PREPALL. For PREPALL, this is the first method to prep.
-
-        Visitor v = null;
-
-        int dashIndex = command.IndexOf('-');
-        string rootCommand = dashIndex < 0 ? command : command.Substring(0, dashIndex);
-        switch (rootCommand)
+        // --- COUNT ---
+        Command countCommand = new Command("COUNT");
         {
-            case "DRIVEALL":
-            case "COUNT":
-                if (args.Length < 2)
+            countCommand.Description = "Count the number of types and methods in an assembly.";
+
+            Argument<string> assemblyArgument = new Argument<string>();
+            assemblyArgument.Arity = ArgumentArity.ExactlyOne;
+            assemblyArgument.Name = "assemblyName";
+            assemblyArgument.Description = "Assembly file to process";
+            countCommand.AddArgument(assemblyArgument);
+
+            countCommand.Handler = CommandHandler.Create<string>((assemblyName) =>
+            {
+                if (File.Exists(assemblyName))
                 {
-                    Console.WriteLine("ERROR: too few arguments");
-                    return Usage();
-                }
-                else if (args.Length > 2)
-                {
-                    Console.WriteLine("ERROR: too many arguments");
-                    return Usage();
+
+                    Visitor v = new Counter();
+                    Worker w = new Worker(v, false);
+                    return w.Work(assemblyName);
                 }
 
-                if (rootCommand == "DRIVEALL")
+                Console.WriteLine($"Failed: assembly '{assemblyName}' does not exist");
+                return 101;
+            });
+        }
+
+        // --- PREPALL ---
+        Command prepallCommand = new Command("PREPALL");
+        {
+            prepallCommand.Description = "JIT all the methods in an assembly or all assemblies in a directory tree.";
+
+            Argument<string> assemblyArgument = new Argument<string>();
+            assemblyArgument.Arity = ArgumentArity.ExactlyOne;
+            assemblyArgument.Name = "assemblyName";
+            assemblyArgument.Description = "Assembly file to process, or directory to recursively traverse";
+            prepallCommand.AddArgument(assemblyArgument);
+
+            Option methodOption = new Option("--method", "Index of the first method to jit", new Argument<int>(0) { Arity = ArgumentArity.ExactlyOne });
+            Option cctorOption = new Option("--cctors", "Try and invoke cctors first", new Argument<bool>());
+            Option quietOption = new Option("--quiet", "Don't show progress messages", new Argument<bool>());
+            Option timeOption = new Option("--time", "Show elapsed time information", new Argument<bool>());
+            prepallCommand.AddOption(methodOption);
+            prepallCommand.AddOption(cctorOption);
+            prepallCommand.AddOption(quietOption);
+            prepallCommand.AddOption(timeOption);
+
+            prepallCommand.Handler = CommandHandler.Create<string, int, bool, bool, bool>((assemblyName, method, cctors, quiet, time) =>
+            {
+                if (File.Exists(assemblyName))
+                {
+                    Visitor v = new PrepareAll(method, !quiet, time);
+                    Worker w = new Worker(v, cctors);
+                    return w.Work(assemblyName);
+                }
+
+#if NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0
+                else if (Directory.Exists(assemblyName))
+                {
+                    EnumerationOptions options = new EnumerationOptions();
+                    options.RecurseSubdirectories = true;
+                    IEnumerable<string> exeFiles = Directory.EnumerateFiles(assemblyName, "*.exe", options);
+                    IEnumerable<string> dllFiles = Directory.EnumerateFiles(assemblyName, "*.dll", options);
+                    IEnumerable<string> allFiles = exeFiles.Concat(dllFiles);
+                    Visitor v = new PrepareAll(method, !quiet, time);
+                    Worker w = new Worker(v, cctors);
+                    return w.Work(allFiles);
+                }
+#endif
+
+                Console.WriteLine($"Failed: '{assemblyName}' does not exist");
+                return 101;
+            });
+        }
+
+        // --- PREPONE ---
+        Command preponeCommand = new Command("PREPONE");
+        {
+            preponeCommand.Description = "JIT exactly one method in an assembly.";
+
+            Argument<string> assemblyArgument = new Argument<string>();
+            assemblyArgument.Arity = ArgumentArity.ExactlyOne;
+            assemblyArgument.Name = "assemblyName";
+            assemblyArgument.Description = "Assembly file to process";
+            preponeCommand.AddArgument(assemblyArgument);
+
+            Option methodOption = new Option("--method", "Index of the method to jit", new Argument<int>(0) { Arity = ArgumentArity.ExactlyOne });
+            Option cctorOption = new Option("--cctors", "Try and invoke cctors first", new Argument<bool>());
+            Option quietOption = new Option("--quiet", "Don't show progress messages", new Argument<bool>());
+            Option timeOption = new Option("--time", "Show elapsed time information", new Argument<bool>());
+            preponeCommand.AddOption(methodOption);
+            preponeCommand.AddOption(cctorOption);
+            preponeCommand.AddOption(quietOption);
+            preponeCommand.AddOption(timeOption);
+
+            preponeCommand.Handler = CommandHandler.Create<string, int, bool, bool, bool>((assemblyName, method, cctors, quiet, time) =>
+            {
+                if (File.Exists(assemblyName))
+                {
+                    Visitor v = new PrepareOne(method, !quiet, time);
+                    Worker w = new Worker(v, cctors);
+                    return w.Work(assemblyName);
+                }
+
+                Console.WriteLine($"Failed: '{assemblyName}' does not exist");
+                return 101;
+            });
+        }
+
+        // --- DRIVEALL ---
+        Command driveallCommand = new Command("DRIVEALL");
+        {
+            driveallCommand.Description = "JIT all the methods in an assembly robustly, skipping methods with asserts.";
+
+            Argument<string> assemblyArgument = new Argument<string>();
+            assemblyArgument.Arity = ArgumentArity.ExactlyOne;
+            assemblyArgument.Name = "assemblyName";
+            assemblyArgument.Description = "Assembly file to process";
+            driveallCommand.AddArgument(assemblyArgument);
+
+            Option cctorOption = new Option("--cctors", "Try and invoke cctors first", new Argument<bool>());
+            Option quietOption = new Option("--quiet", "Don't show progress messages", new Argument<bool>());
+            Option timeOption = new Option("--time", "Show elapsed time information", new Argument<bool>());
+            driveallCommand.AddOption(cctorOption);
+            driveallCommand.AddOption(quietOption);
+            driveallCommand.AddOption(timeOption);
+
+            // Options are ignored here, as DRIVEALL will grab the command line for child invocations of PREPALL.
+            // By including them here we validate them early.
+            driveallCommand.Handler = CommandHandler.Create<string, bool, bool, bool>((assemblyName, cctors, quiet, time) =>
+            {
+                if (File.Exists(assemblyName))
                 {
                     return PMIDriver.PMIDriver.Drive(assemblyName);
                 }
 
-                v = new Counter();
-                break;
-
-            case "PREPALL":
-            case "PREPONE":
-                if (args.Length < 3)
-                {
-                    methodToPrep = 0;
-                }
-                else if (args.Length > 3)
-                {
-                    Console.WriteLine("ERROR: too many arguments");
-                    return Usage();
-                }
-                else
-                {
-                    try
-                    {
-                        methodToPrep = Convert.ToInt32(args[2]);
-                    }
-                    catch (System.FormatException)
-                    {
-                        Console.WriteLine("ERROR: illegal method number");
-                        return Usage();
-                    }
-                }
-
-                bool all = command.IndexOf("ALL") > 0;
-                bool verbose = !(command.IndexOf("QUIET") > 0);
-                bool time = verbose || command.IndexOf("TIME") > 0;
-
-                if (all)
-                {
-                    v = new PrepareAll(methodToPrep, verbose, time);
-                }
-                else
-                {
-                    v = new PrepareOne(methodToPrep, verbose, time);
-                }
-                break;
-
-            default:
-                Console.WriteLine("ERROR: Unknown command {0}", command);
-                return Usage();
+                Console.WriteLine($"Failed: '{assemblyName}' does not exist");
+                return 101;
+            });
         }
 
-        bool runCctors = command.IndexOf("CCTORS") > 0;
+        // --- ROOT ---
+        RootCommand rootCommand = new RootCommand();
+        rootCommand.AddCommand(countCommand);
+        rootCommand.AddCommand(prepallCommand);
+        rootCommand.AddCommand(preponeCommand);
+        rootCommand.AddCommand(driveallCommand);
 
-        Worker w = new Worker(v, runCctors);
-        int result = 0;
-        string msg = "a file";
-
-#if NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0
-        msg += " or a directory";
-        if (Directory.Exists(assemblyName))
-        {
-            EnumerationOptions options = new EnumerationOptions();
-            options.RecurseSubdirectories = true;
-            IEnumerable<string> exeFiles = Directory.EnumerateFiles(assemblyName, "*.exe", options);
-            IEnumerable<string> dllFiles = Directory.EnumerateFiles(assemblyName, "*.dll", options);
-            IEnumerable<string> allFiles = exeFiles.Concat(dllFiles);
-            result = w.Work(allFiles);
-        }
-        else
-#endif
-
-        if (File.Exists(assemblyName))
-        {
-            result = w.Work(assemblyName);
-        }
-        else
-        {
-            Console.WriteLine($"ERROR: {assemblyName} is not {msg}");
-            result = 101;
-        }
-
-        return result;
+        // Parse and execute
+        return rootCommand.InvokeAsync(args).Result;
     }
 }

--- a/src/pmi/pmi.csproj
+++ b/src/pmi/pmi.csproj
@@ -7,6 +7,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(target-framework.props))" />
 
   <ItemGroup>
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19272.1" />
     <PackageReference Include="System.Management" Version="4.5.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Replace PMI's home-grown command line parsing with the new System.CommandLine
version.

Syntax changes slightly as the "suffix" options (eg `PREPALL-QUIET`) now need
to be separated out (`PREPALL --quiet`). Only real "breaking" change is that the
method index for `PREPALL` and `PREPONE` is now a named option.

With this new package we get built in help and (in some shells) command line
completion.

I plan to eventually migrate all the utilites over to this package as the one
they are using is now orphaned and unsupported. See #193.