### PR TITLE
Warning base zero size in jit-diff.

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -365,7 +365,16 @@ namespace ManagedCodeGen
                 Console.Write($" (using filter '{config.Filter}')");
             }
             Console.WriteLine("\n(Lower is better)\n");
-            Console.WriteLine("Total bytes of diff: {0} ({1:P} of base)", totalDeltaBytes, (double)totalDeltaBytes / totalBaseBytes);
+
+            if (totalBaseBytes != 0)
+            {
+                Console.WriteLine("Total bytes of diff: {0} ({1:P} of base)", totalDeltaBytes, (double)totalDeltaBytes / totalBaseBytes);
+            }
+            else 
+            {
+                var totalDiffBytes = fileDeltaList.Sum(x => x.diffBytes);
+                Console.WriteLine("Warning: the base size is 0, the diff size is {0}, have you used a release version?", totalDiffBytes);
+            }
 
             if (totalDeltaBytes != 0)
             {

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -351,7 +351,7 @@ namespace ManagedCodeGen
         //
         public static int Summarize(IEnumerable<FileDelta> fileDeltaList, Config config, Dictionary<string, int> diffCounts)
         {
-            var totalDiffBytes = fileDeltaList.Sum(x => x.deltaBytes);
+            var totalDeltaBytes = fileDeltaList.Sum(x => x.deltaBytes);
             var totalBaseBytes = fileDeltaList.Sum(x => x.baseBytes);
 
             if (config.Note != null)
@@ -365,11 +365,11 @@ namespace ManagedCodeGen
                 Console.Write($" (using filter '{config.Filter}')");
             }
             Console.WriteLine("\n(Lower is better)\n");
-            Console.WriteLine("Total bytes of diff: {0} ({1:P} of base)", totalDiffBytes, (double)totalDiffBytes / totalBaseBytes);
+            Console.WriteLine("Total bytes of diff: {0} ({1:P} of base)", totalDeltaBytes, (double)totalDeltaBytes / totalBaseBytes);
 
-            if (totalDiffBytes != 0)
+            if (totalDeltaBytes != 0)
             {
-                Console.WriteLine("    diff is {0}", totalDiffBytes < 0 ? "an improvement." : "a regression.");
+                Console.WriteLine("    diff is {0}", totalDeltaBytes < 0 ? "an improvement." : "a regression.");
             }
 
             if (config.Reconcile)
@@ -498,7 +498,7 @@ namespace ManagedCodeGen
                 }
             }
 
-            return Math.Abs(totalDiffBytes);
+            return Math.Abs(totalDeltaBytes);
         }
 
         public static void WarnFiles(IEnumerable<FileInfo> diffList, IEnumerable<FileInfo> baseList)


### PR DESCRIPTION
It is pretty easy to run diffs with a release version and get results that look valid: `Total bytes of diff: 0`.

Add a warning message to avoid that.