### PR TITLE
Enable jitutils build with .NET Core 5.0 SDK installed

### DIFF
--- a/src/jit-include.props
+++ b/src/jit-include.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
@@ -12,7 +12,7 @@
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>

--- a/src/target-framework.props
+++ b/src/target-framework.props
@@ -1,12 +1,12 @@
 <Project>
 
-  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('3.0'))">
+  <PropertyGroup Condition="!$(NETCoreSdkVersion.StartsWith('2.1'))">
     <_UseNetCoreApp3>true</_UseNetCoreApp3>
   </PropertyGroup>
 
   <PropertyGroup>
     <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
-	<TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>   
+    <TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>   
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Force targetting netcoreapp3.0 unless we are actually on netcoreapp2.1.

(Maybe 2.1 support should be removed entirely?)