### PR TITLE
Use /artifacts in place of /bin

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -212,7 +212,7 @@ namespace ManagedCodeGen
                     // If the user didn't specify a compile_commands.json, we need to see if one exists, and if not, create it.
                     if (!_untidy && _compileCommands == null)
                     {
-                        string[] compileCommandsPath = { _rootPath, "bin", "nmakeobj", "Windows_NT." + _arch + "." + _build, "compile_commands.json" };
+                        string[] compileCommandsPath = { _rootPath, "artifacts", "nmakeobj", "Windows_NT." + _arch + "." + _build, "compile_commands.json" };
                         _compileCommands = Path.Combine(compileCommandsPath);
                         _rewriteCompileCommands = true;
 
@@ -243,7 +243,7 @@ namespace ManagedCodeGen
                     // If the user didn't specify a compile_commands.json, we need to see if one exists, and if not, create it.
                     if (!_untidy && _compileCommands == null)
                     {
-                        string[] compileCommandsPath = { _rootPath, "bin", "obj", _os + "." + _arch + "." + _build, "compile_commands.json" };
+                        string[] compileCommandsPath = { _rootPath, "artifacts", "obj", _os + "." + _arch + "." + _build, "compile_commands.json" };
                         _compileCommands = Path.Combine(compileCommandsPath);
                         _rewriteCompileCommands = true;
 
@@ -429,7 +429,7 @@ namespace ManagedCodeGen
 
             if (config.DoClangTidy)
             {
-                string[] newCompileCommandsDirPath = { config.CoreCLRRoot, "bin", "obj", config.OS + "." + config.Arch + "." + config.Build };
+                string[] newCompileCommandsDirPath = { config.CoreCLRRoot, "artifacts", "obj", config.OS + "." + config.Arch + "." + config.Build };
                 string compileCommands = config.CompileCommands;
                 string newCompileCommandsDir = Path.Combine(newCompileCommandsDirPath);
                 string newCompileCommands = Path.Combine(newCompileCommandsDir, "compile_commands_full.json");

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -37,6 +37,7 @@ namespace ManagedCodeGen
             private string _os = null;
             private string _build = null;
             private string _rootPath = null;
+            private string _repoRootPath = null;
             private IReadOnlyList<string> _filenames = Array.Empty<string>();
             private IReadOnlyList<string> _projects = Array.Empty<string>();
             private string _srcDirectory = null;
@@ -212,7 +213,7 @@ namespace ManagedCodeGen
                     // If the user didn't specify a compile_commands.json, we need to see if one exists, and if not, create it.
                     if (!_untidy && _compileCommands == null)
                     {
-                        string[] compileCommandsPath = { _rootPath, "artifacts", "nmakeobj", "Windows_NT." + _arch + "." + _build, "compile_commands.json" };
+                        string[] compileCommandsPath = { _rootPath, "..", "..", "artifacts", "nmakeobj", "Windows_NT." + _arch + "." + _build, "compile_commands.json" };
                         _compileCommands = Path.Combine(compileCommandsPath);
                         _rewriteCompileCommands = true;
 
@@ -243,7 +244,7 @@ namespace ManagedCodeGen
                     // If the user didn't specify a compile_commands.json, we need to see if one exists, and if not, create it.
                     if (!_untidy && _compileCommands == null)
                     {
-                        string[] compileCommandsPath = { _rootPath, "artifacts", "obj", _os + "." + _arch + "." + _build, "compile_commands.json" };
+                        string[] compileCommandsPath = { _rootPath, "..", "..", "artifacts", "obj", "coreclr", _os + "." + _arch + "." + _build, "compile_commands.json" };
                         _compileCommands = Path.Combine(compileCommandsPath);
                         _rewriteCompileCommands = true;
 
@@ -429,7 +430,7 @@ namespace ManagedCodeGen
 
             if (config.DoClangTidy)
             {
-                string[] newCompileCommandsDirPath = { config.CoreCLRRoot, "artifacts", "obj", config.OS + "." + config.Arch + "." + config.Build };
+                string[] newCompileCommandsDirPath = { config.CoreCLRRoot, "..", "..", "artifacts", "obj", "coreclr", config.OS + "." + config.Arch + "." + config.Build };
                 string compileCommands = config.CompileCommands;
                 string newCompileCommandsDir = Path.Combine(newCompileCommandsDirPath);
                 string newCompileCommands = Path.Combine(newCompileCommandsDir, "compile_commands_full.json");


### PR DESCRIPTION
@dotnet/jit-contrib ptal

This change is updating format job to use `/artifacts` in place of `/bin`. https://github.com/dotnet/runtime/pull/51 for the change