### PR TITLE
PMI: fix race condition in timer callback

### DIFF
--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -1302,8 +1302,11 @@ class PrepareMethodinator
 
     private static void DummyTimerCallback(object state)
     {
-        timer.Change(Timeout.Infinite, Timeout.Infinite);
-        flag = 1;
+        if (timer != null)
+        {
+            timer.Change(Timeout.Infinite, Timeout.Infinite);
+            flag = 1;
+        }
     }
 
     private static void EnsureTimerCallbackIsJitted()

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -1316,7 +1316,7 @@ class PrepareMethodinator
             callback: new TimerCallback(DummyTimerCallback),
             state: null,
             dueTime: 10,
-            period: Timeout.Infinite);
+            period: 1000);
         while (flag == 0)
         {
             Thread.Sleep(1);

--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -1302,11 +1302,8 @@ class PrepareMethodinator
 
     private static void DummyTimerCallback(object state)
     {
-        if (timer != null)
-        {
-            timer.Change(Timeout.Infinite, Timeout.Infinite);
-            flag = 1;
-        }
+        timer.Change(Timeout.Infinite, Timeout.Infinite);
+        flag = 1;
     }
 
     private static void EnsureTimerCallbackIsJitted()
@@ -1315,8 +1312,9 @@ class PrepareMethodinator
         timer = new Timer(
             callback: new TimerCallback(DummyTimerCallback),
             state: null,
-            dueTime: 10,
-            period: 1000);
+            dueTime: Timeout.Infinite,
+            period: Timeout.Infinite);
+        timer.Change(10, Timeout.Infinite);
         while (flag == 0)
         {
             Thread.Sleep(1);


### PR DESCRIPTION
It's possible for timer to be null when the callback fires. I saw
this a few times when gathering `--tier0` diffs via `jit-diffs`.