### PR TITLE
Add --optimize option to calls to crossgen2.exe.

### DIFF
--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -465,6 +465,8 @@ namespace ManagedCodeGen
                         AddOutputPathOption(commandArgs, nativeOutput);
                     }
 
+                    AddOptimizationOption(commandArgs);
+
                     commandArgs.Add(fullPathAssembly);
 
                     // Pick up ambient COMPlus settings.


### PR DESCRIPTION
This is a follow-up to #228. Unlike crossgen.exe, crossgen2.exe
needs an explicit --optimize option. I added the method to set it
in #228 but forgot to call it from GenerateAsm. This change adds
the missing call.
