### PR TITLE
Update jitutils .NET Core SDK references

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -50,7 +50,7 @@ REM Do as many builds as possible; don't stop on first failure (if any).
 set __ExitCode=0
 
 REM Declare the list of projects
-set projects=jit-diff jit-dasm jit-analyze jit-format cijobs pmi jit-dasm-pmi jit-decisions-analyze
+set projects=jit-diff jit-dasm jit-analyze jit-format pmi jit-dasm-pmi jit-decisions-analyze
 
 REM Build each project
 for %%p in (%projects%) do (

--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ while getopts "hpfb:" opt; do
 done
 
 # declare the array of projects   
-declare -a projects=(jit-dasm jit-diff jit-analyze jit-format cijobs pmi jit-dasm-pmi jit-decisions-analyze)
+declare -a projects=(jit-dasm jit-diff jit-analyze jit-format pmi jit-dasm-pmi jit-decisions-analyze)
 
 # for each project either build or publish
 for proj in "${projects[@]}"

--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -60,7 +60,6 @@ build.sh [-b <BUILD TYPE>] [-f] [-h] [-p] [-t <TARGET>]
     -h              : Show this message.
     -f              : Install default framework directory in <script_root>/fx.
     -p              : Publish utilities.
-    -t <TARGET>     : Target framework. Default is netcoreapp2.0.
 ```
 
 ## 50,000 foot view
@@ -552,8 +551,8 @@ Sample help command line:
 ## packages
 
 This is a skeleton project that exists to pull down a predictable set of framework 
-assemblies and publish them in the root in the subdirectory './fx'.  Today this is 
-set to the NetCoreApp1.0 frameworks.  When this package is installed 
+assemblies and publish them in the root in the subdirectory './fx'.
+When this package is installed 
 via the `build.{cmd|sh}` script this set can be used on any supported platform for 
 diffing.  Note: The mscorlib.dll is removed, as this assembly should be updated from 
 the selected base runtime that is under test, for consistency. To add particular packages 

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -37,7 +37,6 @@ namespace ManagedCodeGen
             private string _os = null;
             private string _build = null;
             private string _rootPath = null;
-            private string _repoRootPath = null;
             private IReadOnlyList<string> _filenames = Array.Empty<string>();
             private IReadOnlyList<string> _projects = Array.Empty<string>();
             private string _srcDirectory = null;

--- a/src/jit-include.props
+++ b/src/jit-include.props
@@ -2,14 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="runtime.native.System" Version="4.3.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/jit-include.props
+++ b/src/jit-include.props
@@ -1,20 +1,15 @@
 <Project>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
     <PackageReference Include="runtime.native.System" Version="4.3.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 
 </Project>

--- a/src/mutate-test/mutate-test.csproj
+++ b/src/mutate-test/mutate-test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Mutate</RootNamespace>
     <AssemblyName>Mutate</AssemblyName>
     <LangVersion>7.3</LangVersion>

--- a/src/pmi/pmi.csproj
+++ b/src/pmi/pmi.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Management" Version="4.5.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/target-framework.props
+++ b/src/target-framework.props
@@ -1,12 +1,12 @@
 <Project>
 
-  <PropertyGroup Condition="!$(NETCoreSdkVersion.StartsWith('2.1'))">
+  <PropertyGroup Condition="!$(NETCoreSdkVersion.StartsWith('5'))">
     <_UseNetCoreApp3>true</_UseNetCoreApp3>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp2.1</TargetFramework>   
+    <TargetFramework Condition="$(_UseNetCoreApp3) == true">netcoreapp3.1</TargetFramework>
+    <TargetFramework Condition="$(_UseNetCoreApp3) != true">netcoreapp5.0</TargetFramework>   
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Move from 3.0 to 3.1
- If 5.0 is installed, use that
- Stop building obsolete cijobs (I didn't want to delete it just yet; maybe
it could be repurposed for AzDO?)