### PR TITLE
Fixup jitutils to work with the dotnet/runtime repo

### DIFF
--- a/src/jit-format/README.md
+++ b/src/jit-format/README.md
@@ -13,7 +13,7 @@ To build/setup:
 * Issue a 'dotnet build' command.  This will create a jit-format in the bin
   directory that you can use to check the formatting of your changes.
 * Invoke jit-format -a `<arch>` -b `<build>` -p `<platform>` 
-  --coreclr `<path to coreclr root>`
+  --coreclr `<path to runtime root>`
 * jit-format can be installed by running the project build script in the root of this repo 
 via
 

--- a/src/jit-format/README.md
+++ b/src/jit-format/README.md
@@ -13,7 +13,7 @@ To build/setup:
 * Issue a 'dotnet build' command.  This will create a jit-format in the bin
   directory that you can use to check the formatting of your changes.
 * Invoke jit-format -a `<arch>` -b `<build>` -p `<platform>` 
-  --coreclr `<path to runtime root>`
+  --runtime `<path to runtime root>`
 * jit-format can be installed by running the project build script in the root of this repo 
 via
 

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -60,7 +60,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("a|arch", ref _arch, "The architecture of the build (options: x64, x86)");
                     syntax.DefineOption("o|os", ref _os, "The operating system of the build (options: Windows, OSX, Ubuntu, Fedora, etc.)");
                     syntax.DefineOption("b|build", ref _build, "The build type of the build (options: Release, Checked, Debug)");
-                    syntax.DefineOption("c|coreclr", ref _rootPath, "Full path to base coreclr directory");
+                    syntax.DefineOption("c|coreclr", ref _rootPath, "Full path to base runtime directory");
                     syntax.DefineOption("compile-commands", ref _compileCommands, "Full path to compile_commands.json");
                     syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
                     syntax.DefineOption("untidy", ref _untidy, "Do not run clang-tidy");
@@ -198,11 +198,11 @@ namespace ManagedCodeGen
                 if (!Directory.Exists(_rootPath))
                 {
                     // If _rootPath doesn't exist, it is an invalid path
-                    _syntaxResult.ReportError("Invalid path to coreclr directory. Specify with --coreclr");
+                    _syntaxResult.ReportError("Invalid path to runtime directory. Specify with --coreclr");
                 }
                 else if (!File.Exists(Path.Combine(_rootPath, "build.cmd")) || !File.Exists(Path.Combine(_rootPath, "build.sh")))
                 {
-                    // If _rootPath\build.cmd or _rootPath\build.sh do not exist, it is an invalid path to a coreclr repo
+                    // If _rootPath\build.cmd or _rootPath\build.sh do not exist, it is an invalid path to a runtime repo
                     _syntaxResult.ReportError("Invalid path to coreclr directory. Specify with --coreclr");
                 }
 

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -60,7 +60,8 @@ namespace ManagedCodeGen
                     syntax.DefineOption("a|arch", ref _arch, "The architecture of the build (options: x64, x86)");
                     syntax.DefineOption("o|os", ref _os, "The operating system of the build (options: Windows, OSX, Ubuntu, Fedora, etc.)");
                     syntax.DefineOption("b|build", ref _build, "The build type of the build (options: Release, Checked, Debug)");
-                    syntax.DefineOption("c|coreclr", ref _rootPath, "Full path to base runtime directory");
+                    syntax.DefineOption("c|coreclr", ref _rootPath, "Full path to base runtime directory. Exists for back-compat; use --runtime");
+                    syntax.DefineOption("r|runtime", ref _rootPath, "Full path to base runtime directory");
                     syntax.DefineOption("compile-commands", ref _compileCommands, "Full path to compile_commands.json");
                     syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
                     syntax.DefineOption("untidy", ref _untidy, "Do not run clang-tidy");
@@ -182,28 +183,28 @@ namespace ManagedCodeGen
                 {
                     if (_verbose)
                     {
-                        Console.WriteLine("Discovering --coreclr.");
+                        Console.WriteLine("Discovering --runtime.");
                     }
                     _rootPath = Utility.GetRepoRoot(_verbose);
                     if (_rootPath == null)
                     {
-                        _syntaxResult.ReportError("Specify --coreclr");
+                        _syntaxResult.ReportError("Specify --runtime");
                     }
                     else
                     {
-                        Console.WriteLine("Using --coreclr={0}", _rootPath);
+                        Console.WriteLine("Using --runtime={0}", _rootPath);
                     }
                 }
 
                 if (!Directory.Exists(_rootPath))
                 {
                     // If _rootPath doesn't exist, it is an invalid path
-                    _syntaxResult.ReportError("Invalid path to runtime directory. Specify with --coreclr");
+                    _syntaxResult.ReportError("Invalid path to runtime directory. Specify with --runtime");
                 }
                 else if (!File.Exists(Path.Combine(_rootPath, "build.cmd")) || !File.Exists(Path.Combine(_rootPath, "build.sh")))
                 {
                     // If _rootPath\build.cmd or _rootPath\build.sh do not exist, it is an invalid path to a runtime repo
-                    _syntaxResult.ReportError("Invalid path to coreclr directory. Specify with --coreclr");
+                    _syntaxResult.ReportError("Invalid path to coreclr directory. Specify with --runtime");
                 }
 
                 // Check that we can find compile_commands.json on windows

--- a/src/util/util.cs
+++ b/src/util/util.cs
@@ -21,7 +21,7 @@ namespace ManagedCodeGen
             return resultPath;
         }
 
-        // GetRepoRoot: Determine if the current directory is within the directory tree of a dotnet/coreclr
+        // GetRepoRoot: Determine if the current directory is within the directory tree of a dotnet/runtime
         // repo clone. Depends on "git".
         public static string GetRepoRoot(bool verbose = false)
         {
@@ -41,7 +41,7 @@ namespace ManagedCodeGen
             var git_root = lines[0];
             var repo_root = git_root.Replace('/', Path.DirectorySeparatorChar);
 
-            // Is it actually the dotnet/coreclr repo?
+            // Is it actually the dotnet/runtime repo?
             commandArgs = new List<string> { "remote", "-v" };
             result = TryCommand("git", commandArgs, true);
             if (result.ExitCode != 0)
@@ -53,12 +53,12 @@ namespace ManagedCodeGen
                 return null;
             }
 
-            bool isCoreClr = result.StdOut.Contains("/coreclr");
-            if (!isCoreClr)
+            bool isRuntime = result.StdOut.Contains("/runtime");
+            if (!isRuntime)
             {
                 if (verbose)
                 {
-                    Console.Error.WriteLine("Doesn't appear to be the dotnet/coreclr repo:");
+                    Console.Error.WriteLine("Doesn't appear to be the dotnet/runtime repo:");
                     Console.Error.WriteLine(result.StdOut);
                 }
                 return null;


### PR DESCRIPTION
This resolves https://github.com/dotnet/jitutils/issues/230 ~~https://github.com/dotnet/jitutils/issues/243~~

This does not provide any switch to continue working on dotnet/coreclr, as I assume there wont be any significant changes and devs needing to test changes can always use an older snapshot of jitutils (such as commit 7e6c68b913c3b0a06821ae77a184d681d3ecefc6 or prior).