### PR TITLE
Fix reconciliation math in PMI

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -441,8 +441,8 @@ namespace ManagedCodeGen
                 }
 
                 methodDeltaList = methodDeltaList.Concat(reconciles);
-                deltaMetrics.Add(reconciledBaseMetrics);
-                deltaMetrics.Sub(reconciledDiffMetrics);
+                deltaMetrics.Sub(reconciledBaseMetrics);
+                deltaMetrics.Add(reconciledDiffMetrics);
             }
         }
 


### PR DESCRIPTION
Delta is always diff - base. So we need to subtract base and add diff;
I had it reversed.