### PR TITLE
Replacing Custom Oses with versionless rids

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,32 +12,32 @@ function get_host_os {
     OSName=$(uname -s)
     case $OSName in
         Linux)
-            __HostOS=Linux
+            __HostOS=linux
             ;;
 
         Darwin)
-            __HostOS=OSX
+            __HostOS=osx
             ;;
 
         FreeBSD)
-            __HostOS=FreeBSD
+            __HostOS=freebsd
             ;;
 
         OpenBSD)
-            __HostOS=OpenBSD
+            __HostOS=openbsd
             ;;
 
         NetBSD)
-            __HostOS=NetBSD
+            __HostOS=netbsd
             ;;
 
         SunOS)
-            __HostOS=SunOS
+            __HostOS=sunos
             ;;
 
         *)
             echo "Unsupported OS $OSName detected, configuring as if for Linux"
-            __HostOS=Linux
+            __HostOS=linux
             ;;
     esac
 }
@@ -57,7 +57,7 @@ function download_tools {
 
     if ! hash wget 2>/dev/null; then
         echo "Error: wget not found; not downloading clang-format and clang-tidy."
-        if [ "$__HostOS" == "OSX" ]; then
+        if [ "$__HostOS" == "osx" ]; then
             echo "On OSX, install wget using Homebrew (https://brew.sh/) using 'brew install wget'."
         fi
         return 1

--- a/doc/cijobs.md
+++ b/doc/cijobs.md
@@ -65,7 +65,7 @@ The "cijobs copy" command has the following help message:
 
 ## Using cijobs
 
-A common question for a developer might be "what is the last successful  checked build?"
+A common question for a developer might be "what is the last successful OSX  checked build?"
 
 ```
 $ cijobs list --match "osx"

--- a/doc/cijobs.md
+++ b/doc/cijobs.md
@@ -65,7 +65,7 @@ The "cijobs copy" command has the following help message:
 
 ## Using cijobs
 
-A common question for a developer might be "what is the last successful OSX  checked build?"
+A common question for a developer might be "what is the last successful OSX checked build?"
 
 ```
 $ cijobs list --match "osx"

--- a/doc/cijobs.md
+++ b/doc/cijobs.md
@@ -65,7 +65,7 @@ The "cijobs copy" command has the following help message:
 
 ## Using cijobs
 
-A common question for a developer might be "what is the last successful OSX checked build?"
+A common question for a developer might be "what is the last successful  checked build?"
 
 ```
 $ cijobs list --match "osx"

--- a/doc/config.md
+++ b/doc/config.md
@@ -52,7 +52,7 @@ Sample config.json:
     "default": {
       "arch": "x64",
       "build": "Checked",
-      "os": "Windows_NT",
+      "os": "win",
       "coreclr": "C:\\michelm\\coreclr",
       "verbose": "true",
       "fix": "true"
@@ -61,7 +61,7 @@ Sample config.json:
   "asmdiff": {
     "default": {
       "base": "checked_osx-1526",
-      "diff": "/Users/russellhadley/Work/dotnet/coreclr/bin/Product/OSX.x64.Checked",
+      "diff": "/Users/russellhadley/Work/dotnet/coreclr/bin/Product/.x64.Checked",
       "frameworks": "true",
       "output": "/Users/russellhadley/Work/dotnet/output",
       "core_root": "/Users/russellhadley/Work/dotnet/jitutils/fx"
@@ -69,19 +69,19 @@ Sample config.json:
     "tools": [
       {
         "tag": "checked_osx-1439",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1439/Product/OSX.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1439/Product/.x64.Checked"
       },
       {
         "tag": "checked_osx-1442",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1442/Product/OSX.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1442/Product/.x64.Checked"
       },
       {
         "tag": "checked_osx-1443",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1443/Product/OSX.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1443/Product/.x64.Checked"
       },
       {
         "tag": "checked_osx-1526",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1526/Product/OSX.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1526/Product/.x64.Checked"
       }
     ]
   }
@@ -99,7 +99,7 @@ $ jit-diff list
 
 Defaults:
 	base: checked_osx-1526
-	diff: /Users/russellhadley/Work/dotnet/coreclr/bin/Product/OSX.x64.Checked
+	diff: /Users/russellhadley/Work/dotnet/coreclr/bin/Product/.x64.Checked
 	output: /Users/russellhadley/Work/dotnet/output
 	core_root: /Users/russellhadley/Work/dotnet/jitutils/fx
 	frameworks: true

--- a/doc/config.md
+++ b/doc/config.md
@@ -61,7 +61,7 @@ Sample config.json:
   "asmdiff": {
     "default": {
       "base": "checked_osx-1526",
-      "diff": "/Users/russellhadley/Work/dotnet/coreclr/bin/Product/.x64.Checked",
+      "diff": "/Users/russellhadley/Work/dotnet/coreclr/bin/Product/osx.x64.Checked",
       "frameworks": "true",
       "output": "/Users/russellhadley/Work/dotnet/output",
       "core_root": "/Users/russellhadley/Work/dotnet/jitutils/fx"
@@ -69,19 +69,19 @@ Sample config.json:
     "tools": [
       {
         "tag": "checked_osx-1439",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1439/Product/.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1439/Product/osx.x64.Checked"
       },
       {
         "tag": "checked_osx-1442",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1442/Product/.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1442/Product/osx.x64.Checked"
       },
       {
         "tag": "checked_osx-1443",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1443/Product/.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1443/Product/osx.x64.Checked"
       },
       {
         "tag": "checked_osx-1526",
-        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1526/Product/.x64.Checked"
+        "path": "/Users/russellhadley/Work/dotnet/output/tools/checked_osx-1526/Product/osx.x64.Checked"
       }
     ]
   }
@@ -99,7 +99,7 @@ $ jit-diff list
 
 Defaults:
 	base: checked_osx-1526
-	diff: /Users/russellhadley/Work/dotnet/coreclr/bin/Product/.x64.Checked
+	diff: /Users/russellhadley/Work/dotnet/coreclr/bin/Product/osx.x64.Checked
 	output: /Users/russellhadley/Work/dotnet/output
 	core_root: /Users/russellhadley/Work/dotnet/jitutils/fx
 	frameworks: true

--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -199,12 +199,12 @@ The "jit-diff diff" command has this help message:
     
     Examples:
     
-      jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root --base c:\coreclr_base\bin\Product
-    \Windows_NT.x64.Checked --diff c:\coreclr\bin\Product\Windows_NT.x86.Checked
+      jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\win.x64.Release\Tests\Core_Root --base c:\coreclr_base\bin\Product
+    \win.x64.Checked --diff c:\coreclr\bin\Product\win.x86.Checked
           Generate diffs of System.Private.CoreLib.dll by specifying baseline and
           diff compiler directories explicitly.
     
-      jit-diff diff --output c:\diffs --base c:\coreclr_base\bin\Product\Windows_NT.x64.Checked --diff
+      jit-diff diff --output c:\diffs --base c:\coreclr_base\bin\Product\win.x64.Checked --diff
           If run within the c:\coreclr git clone of dotnet/coreclr, does the same
           as the prevous example, using defaults.
     
@@ -267,7 +267,7 @@ The tool needs to know:
 These can all be specified explicitly. For example:
 
 ```
-    c:\coreclr> jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\Windows_NT.x64.release\Tests\Core_Root --base e:\coreclr2\bin\Product\Windows_NT.x64.checked --diff c:\coreclr\bin\Product\Windows_NT.x64.checked --crossgen c:\coreclr\bin\Product\Windows_NT.x64.release
+    c:\coreclr> jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\win.x64.release\Tests\Core_Root --base e:\coreclr2\bin\Product\win.x64.checked --diff c:\coreclr\bin\Product\win.x64.checked --crossgen c:\coreclr\bin\Product\win.x64.release
 ```
 
 Explanation:

--- a/doc/formatting.md
+++ b/doc/formatting.md
@@ -49,7 +49,7 @@ A common task for developers is to format their changes before submitting a GitH
 A developer can run the tool using the tests/scripts/format.py script in the coreclr repo:
 
 ```
-python tests\scripts\format.py --coreclr C:\gh\coreclr --arch x64 --os Windows_NT
+python tests\scripts\format.py --coreclr C:\gh\coreclr --arch x64 --os win
 ```
 
 This will run all build flavors and all projects for the user. This should be done on both
@@ -79,13 +79,13 @@ jit-format -a x64 -b Debug -o Windows -c C:\gh\coreclr -v lower.cpp codegenxarch
 Formatting jit directory.
 Formatting dll project.
 Building compile_commands.json.
-Using compile_commands.json found at C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json
+Using compile_commands.json found at C:\gh\coreclr\bin\obj\win.x64.Checked\compile_commands.json
 Running clang-tidy.
 Running:
-        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
+        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\win.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
 
 Running:
-        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
+        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\win.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
 
 Running: clang-format   C:\gh\coreclr\src\jit\codegenxarch.cpp
 Running: clang-format   C:\gh\coreclr\src\jit\lower.cpp
@@ -103,13 +103,13 @@ jit-format -a x64 -b Debug -o Windows -c C:\gh\coreclr -v --fix lower.cpp codege
 Formatting jit directory.
 Formatting dll project.
 Building compile_commands.json.
-Using compile_commands.json found at C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json
+Using compile_commands.json found at C:\gh\coreclr\bin\obj\win.x64.Checked\compile_commands.json
 Running clang-tidy.
 Running:
-        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
+        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\win.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
 
 Running:
-        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
+        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\win.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
 
 Running: clang-format -i  C:\gh\coreclr\src\jit\codegenxarch.cpp
 Running: clang-format -i  C:\gh\coreclr\src\jit\lower.cpp

--- a/sample_config.json
+++ b/sample_config.json
@@ -11,19 +11,19 @@
         "tools": [
             {
                 "tag": "checked_osx-1439",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1439/Product/.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1439/Product/osx.x64.Checked"
             },
             {
                 "tag": "checked_osx-1442",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1442/Product/.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1442/Product/osx.x64.Checked"
             },
             {
                 "tag": "checked_osx-1443",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1443/Product/.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1443/Product/osx.x64.Checked"
             },
             {
                 "tag": "checked_osx-1526",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1526/Product/.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1526/Product/osx.x64.Checked"
             }
         ]
     },

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,29 +1,29 @@
 {
     "asmdiff" : {
         "default": {
-            "base": "e:\\gh\\coreclr2\\bin\\Product\\Windows_NT.x86.checked",
-            "diff": "c:\\gh\\coreclr\\bin\\Product\\Windows_NT.x86.checked",
+            "base": "e:\\gh\\coreclr2\\bin\\Product\\win.x86.checked",
+            "diff": "c:\\gh\\coreclr\\bin\\Product\\win.x86.checked",
             "frameworks": "true",
             "output": "c:\\diffs",
-            "core_root": "c:\\gh\\coreclr\\bin\\tests\\Windows_NT.x86.checked\\Tests\\Core_Root",
-            "test_root": "c:\\gh\\coreclr\\bin\\tests\\Windows_NT.x86.Release"
+            "core_root": "c:\\gh\\coreclr\\bin\\tests\\win.x86.checked\\Tests\\Core_Root",
+            "test_root": "c:\\gh\\coreclr\\bin\\tests\\win.x86.Release"
         },
         "tools": [
             {
                 "tag": "checked_osx-1439",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1439/Product/OSX.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1439/Product/.x64.Checked"
             },
             {
                 "tag": "checked_osx-1442",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1442/Product/OSX.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1442/Product/.x64.Checked"
             },
             {
                 "tag": "checked_osx-1443",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1443/Product/OSX.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1443/Product/.x64.Checked"
             },
             {
                 "tag": "checked_osx-1526",
-                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1526/Product/OSX.x64.Checked"
+                "path": "/Users/russellhadley/Work/glue/output/tools/checked_osx-1526/Product/.x64.Checked"
             }
         ]
     },
@@ -31,7 +31,7 @@
         "default": {
             "arch": "x64",
             "build": "Checked",
-            "os": "Windows_NT",
+            "os": "win",
             "coreclr": "C:\\gh\\coreclr",
             "verbose": "true",
             "fix": "true",

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -99,11 +99,11 @@ namespace ManagedCodeGen
             switch (platformMoniker)
             {
                 case "Windows":
-                    return "Windows_NT";
+                    return "win";
                 case "Linux":
-                    return "Linux";
+                    return "linux";
                 case "OSX":
-                    return "OSX";
+                    return "osx";
                 default:
                     Console.Error.WriteLine("No platform mapping! (Platform moniker = {0})", platformMoniker);
                     return null;
@@ -381,9 +381,9 @@ namespace ManagedCodeGen
                     // --crossgen and --core_root need to be from the same build.
                     //
                     // E.g.:
-                    //    test_root: c:\gh\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release
-                    //    Core_Root: c:\gh\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root
-                    //    base/diff: c:\gh\runtime\artifacts\bin\coreclr\Windows_NT.x64.Checked
+                    //    test_root: c:\gh\runtime\artifacts\tests\coreclr\win.x64.Release
+                    //    Core_Root: c:\gh\runtime\artifacts\tests\coreclr\win.x64.Release\Tests\Core_Root
+                    //    base/diff: c:\gh\runtime\artifacts\bin\coreclr\win.x64.Checked
 
                     List<string> archList;
                     List<string> buildList;
@@ -733,11 +733,11 @@ namespace ManagedCodeGen
                     string[] diffExampleText = {
                     @"Examples:",
                     @"",
-                    @"  jit-diff diff --output c:\diffs --corelib --core_root c:\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root --base c:\runtime_base\artifacts\bin\coreclr\Windows_NT.x64.Checked --diff c:\runtime\artifacts\bin\coreclr\Windows_NT.x86.Checked",
+                    @"  jit-diff diff --output c:\diffs --corelib --core_root c:\runtime\artifacts\tests\coreclr\win.x64.Release\Tests\Core_Root --base c:\runtime_base\artifacts\bin\coreclr\win.x64.Checked --diff c:\runtime\artifacts\bin\coreclr\win.x86.Checked",
                     @"      Generate diffs of prejitted code for System.Private.CoreLib.dll by specifying baseline and",
                     @"      diff compiler directories explicitly.",
                     @"",
-                    @"  jit-diff diff --output c:\diffs --base c:\runtime_base\artifacts\bin\coreclr\Windows_NT.x64.Checked --diff",
+                    @"  jit-diff diff --output c:\diffs --base c:\runtime_base\artifacts\bin\coreclr\win.x64.Checked --diff",
                     @"      If run within the c:\runtime git clone of dotnet/runtime, does the same",
                     @"      as the prevous example, using defaults.",
                     @"",

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -104,16 +104,16 @@ namespace ManagedCodeGen
                     {
                         if (match.Groups[1].Value.Trim() == "Windows")
                         {
-                            _os = "Windows_NT";
+                            _os = "win";
                         }
                         else if (match.Groups[1].Value.Trim() == "Darwin")
                         {
-                            _os = "OSX";
+                            _os = "osx";
                         }
                         else if (match.Groups[1].Value.Trim() == "Linux")
                         {
                             // Assuming anything other than Windows or OSX is a Linux flavor
-                            _os = "Linux";
+                            _os = "linux";
                         }
                         else
                         {
@@ -162,7 +162,7 @@ namespace ManagedCodeGen
 
                 if (_os == "Windows")
                 {
-                    _os = "Windows_NT";
+                    _os = "win";
                 }
 
                 if (_srcDirectory == null)
@@ -214,12 +214,12 @@ namespace ManagedCodeGen
                 }
 
                 // Check that we can find compile_commands.json on windows
-                if (_os == "Windows_NT")
+                if (_os == "win")
                 {
                     // If the user didn't specify a compile_commands.json, we need to see if one exists, and if not, create it.
                     if (!_untidy && _compileCommands == null)
                     {
-                        string[] compileCommandsPath = { _rootPath, "..", "..", "artifacts", "nmakeobj", "Windows_NT." + _arch + "." + _build, "compile_commands.json" };
+                        string[] compileCommandsPath = { _rootPath, "..", "..", "artifacts", "nmakeobj", "win" + _arch + "." + _build, "compile_commands.json" };
                         _compileCommands = Path.Combine(compileCommandsPath);
                         _rewriteCompileCommands = true;
 
@@ -370,7 +370,7 @@ namespace ManagedCodeGen
                 return default(T);
             }
 
-            public bool IsWindows { get { return (_os == "Windows_NT"); } }
+            public bool IsWindows { get { return (_os == "win"); } }
             public bool DoVerboseOutput { get { return _verbose; } }
             public bool DoClangTidy { get { return !_untidy; } }
             public bool DoClangFormat { get { return !_noformat; } }


### PR DESCRIPTION
Relate runtime PR https://github.com/dotnet/runtime/pull/33315

This change is required to enable to pass the win formatting leg.