### PR TITLE
Fix the loop calling clang-tidy.

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -615,7 +615,10 @@ namespace ManagedCodeGen
             {
                 Parallel.ForEach(filenames, (filename) =>
                     {
-                        formatOk &= DoClangTidyInnerLoop(fix, ignoreErrors, checks, compileCommands, filename, verbose);
+                        if (!DoClangTidyInnerLoop(fix, ignoreErrors, checks, compileCommands, filename, verbose))
+                        {
+                            formatOk = false;
+                        }
                     });
             }
 


### PR DESCRIPTION
`formatOk` wasn't updated in a thread-safe way, which resulted in errors
occasionally not being reported from formatting jobs.

Fixes https://github.com/dotnet/runtime/issues/34336