### PR TITLE
Fix links to Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 This repo holds a collection of utilities used by RyuJIT developers to 
 automate tasks when working on CoreCLR.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 ## Summary
 
 Current tools include:


### PR DESCRIPTION
For more details, see [PR16](https://github.com/dotnet/org-policy/blob/master/doc/PR16.md).