### PR TITLE
Update macOS version.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,4 +21,4 @@ jobs:
   parameters:
     agentOs: macOS
     pool:
-      vmImage: macOS-10.13
+      vmImage: macOS-10.15


### PR DESCRIPTION
Azure Pipelines removed support for macOS 10.13 so we need
to update azure-pipelines.yml to macOS 10.15.