### PR TITLE
Add --nodiffable option

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -44,6 +44,7 @@ namespace ManagedCodeGen
         private bool _dumpDebugInfo = false;
         private bool _noCopyJit = false;
         private bool _verbose = false;
+        private bool _noDiffable = false;
         private bool _tier0 = false;
         private bool _cctors = false;
 
@@ -59,6 +60,7 @@ namespace ManagedCodeGen
                 syntax.DefineOption("gcinfo", ref _dumpGCInfo, "Add GC info to the disasm output.");
                 syntax.DefineOption("debuginfo", ref _dumpDebugInfo, "Add Debug info to the disasm output.");
                 syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
+                syntax.DefineOption("nodiffable", ref _noDiffable, "Generate non-diffable asm (pointer values will be left in output).");
                 syntax.DefineOption("tier0", ref this._tier0, "Generate tier0 code.");
                 syntax.DefineOption("cctors", ref _cctors, "Jit and run cctors before jitting other methods");
                 syntax.DefineOption("r|recursive", ref _recursive, "Scan directories recursively.");
@@ -147,6 +149,7 @@ namespace ManagedCodeGen
         public bool DumpGCInfo { get { return _dumpGCInfo; } }
         public bool DumpDebugInfo { get { return _dumpDebugInfo; } }
         public bool DoVerboseOutput { get { return _verbose; } }
+        public bool NoDiffable { get { return _noDiffable; } }
         public bool CopyJit { get { return !_noCopyJit; } }
         public string CorerunExecutable { get { return _corerunExe; } }
         public string JitPath { get { return _jitPath; } }
@@ -511,7 +514,10 @@ namespace ManagedCodeGen
                     AppendEnvironmentVariableToPmiEnv("COMPlus_JitDisasmAssemblies", Path.GetFileNameWithoutExtension(assembly.Name));
                     AppendEnvironmentVariableToPmiEnv("COMPlus_JitUnwindDump", "*");
                     AppendEnvironmentVariableToPmiEnv("COMPlus_JitEHDump", "*");
-                    AppendEnvironmentVariableToPmiEnv("COMPlus_JitDiffableDasm", "1");
+                    if (!this._config.NoDiffable)
+                    {
+                        AppendEnvironmentVariableToPmiEnv("COMPlus_JitDiffableDasm", "1");
+                    }
                     AppendEnvironmentVariableToPmiEnv("COMPlus_ReadyToRun", "0");
                     AppendEnvironmentVariableToPmiEnv("COMPlus_ZapDisable", "1");
                     AppendEnvironmentVariableToPmiEnv("COMPlus_JitEnableNoWayAssert", "1");    // Force noway_assert to generate assert (not fall back to MinOpts).

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -55,6 +55,7 @@ namespace ManagedCodeGen
         private bool _dumpGCInfo = false;
         private bool _dumpDebugInfo = false;
         private bool _verbose = false;
+        private bool _noDiffable = false;
         private CodeGenerator _codeGenerator;
 
         public Config(string[] args)
@@ -69,6 +70,7 @@ namespace ManagedCodeGen
                 syntax.DefineOption("gcinfo", ref _dumpGCInfo, "Add GC info to the disasm output.");
                 syntax.DefineOption("debuginfo", ref _dumpDebugInfo, "Add Debug info to the disasm output.");
                 syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
+                syntax.DefineOption("nodiffable", ref _noDiffable, "Generate non-diffable asm (pointer values will be left in output).");
                 var waitArg = syntax.DefineOption("w|wait", ref _wait, "Wait for debugger to attach.");
                 waitArg.IsHidden = true;
 
@@ -165,6 +167,7 @@ namespace ManagedCodeGen
         public bool DumpGCInfo { get { return _dumpGCInfo; } }
         public bool DumpDebugInfo { get { return _dumpDebugInfo; } }
         public bool DoVerboseOutput { get { return _verbose; } }
+        public bool NoDiffable { get { return _noDiffable; } }
         public string CrossgenExecutable { get { return _crossgenExe; } }
         public string JitPath { get { return _jitPath; } }
         public string AltJit { get { return _altjit; } }
@@ -483,7 +486,10 @@ namespace ManagedCodeGen
                     AddEnvironmentVariable("COMPlus_NgenDisasm", "*");
                     AddEnvironmentVariable("COMPlus_NgenUnwindDump", "*");
                     AddEnvironmentVariable("COMPlus_NgenEHDump", "*");
-                    AddEnvironmentVariable("COMPlus_JitDiffableDasm", "1");
+                    if (!this._config.NoDiffable)
+                    {
+                        AddEnvironmentVariable("COMPlus_JitDiffableDasm", "1");
+                    }
                     AddEnvironmentVariable("COMPlus_JitEnableNoWayAssert", "1");    // Force noway_assert to generate assert (not fall back to MinOpts).
                     AddEnvironmentVariable("COMPlus_JitNoForceFallback", "1");      // Don't stress noway fallback path.
                     AddEnvironmentVariable("COMPlus_JitRequired", "1");             // Force NO_WAY to generate assert. Also generates assert for BADCODE/BADCODE3.

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -594,6 +594,11 @@ namespace ManagedCodeGen
                 dasmArgs.Add("--jit");
                 dasmArgs.Add(jitPath);
 
+                if (m_config.NoDiffable)
+                {
+                    dasmArgs.Add("--nodiffable");
+                }
+
                 return dasmArgs;
             }
         }
@@ -645,6 +650,11 @@ namespace ManagedCodeGen
 
                 // jit-diffs will handle installing the right jit
                 dasmArgs.Add("--nocopy");
+
+                if (m_config.NoDiffable)
+                {
+                    dasmArgs.Add("--nodiffable");
+                }
 
                 return dasmArgs;
             }

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-//using System.Diagnostics;
 using System.CommandLine;
 using System.IO;
 using System.Collections.Generic;
@@ -11,9 +10,7 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Common;
-//using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-//using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 
@@ -137,6 +134,7 @@ namespace ManagedCodeGen
             private bool _gcinfo = false;
             private bool _debuginfo = false;
             private bool _verbose = false;
+            private bool _noDiffable = false;
             private bool _tier0 = false;
             private string _jobName = null;
             private string _number = null;
@@ -185,6 +183,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("gcinfo", ref _gcinfo, "Add GC info to the disasm output.");
                     syntax.DefineOption("debuginfo", ref _debuginfo, "Add Debug info to the disasm output.");
                     syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
+                    syntax.DefineOption("nodiffable", ref _noDiffable, "Generate non-diffable asm (pointer values will be left in output).");
                     syntax.DefineOption("core_root", ref _platformPath, "Path to test CORE_ROOT.");
                     syntax.DefineOption("test_root", ref _testPath, "Path to test tree. Use with --benchmarks or --tests.");
                     syntax.DefineOption("base_root", ref _baseRoot, "Path to root of base dotnet/runtime repo.");
@@ -278,6 +277,24 @@ namespace ManagedCodeGen
                         _platformName = platMatch.Groups[1].Value;
                         continue;
                     }
+                }
+
+                if (_rid == null)
+                {
+                    Console.WriteLine("Couldn't find RID in 'dotnet --info' output:");
+                    Console.WriteLine("stdout:");
+                    Console.WriteLine("{0}", result.StdOut);
+                    Console.WriteLine("stderr:");
+                    Console.WriteLine("{0}", result.StdErr);
+                }
+
+                if (_platformName == null)
+                {
+                    Console.WriteLine("Couldn't find Platform in 'dotnet --info' output:");
+                    Console.WriteLine("stdout:");
+                    Console.WriteLine("{0}", result.StdOut);
+                    Console.WriteLine("stderr:");
+                    Console.WriteLine("{0}", result.StdErr);
                 }
             }
 
@@ -1244,6 +1261,7 @@ namespace ManagedCodeGen
             public bool GenerateGCInfo { get { return _gcinfo; } }
             public bool GenerateDebugInfo { get { return _debuginfo; } }
             public bool Verbose { get { return _verbose; } }
+            public bool NoDiffable { get { return _noDiffable; } }
             public bool Tier0 { get { return _tier0; } }
             public bool DoAnalyze { get { return !_noanalyze; } }
             public Commands DoCommand { get { return _command; } }


### PR DESCRIPTION
Add --nodiffable to jit-dasm, jit-dasm-pmi, jit-diff.
This is useful for using these tools to generate disassembly
to examine, not to diff.

Also, add some more output if "dotnet --info" doesn't work
as expected.