### PR TITLE
AnalyzeAsm analysis and print assembly

### DIFF
--- a/src/AnalyzeAsm/AnalyzeAsm.csproj
+++ b/src/AnalyzeAsm/AnalyzeAsm.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/src/AnalyzeAsm/OccuranceInfo.cs
+++ b/src/AnalyzeAsm/OccuranceInfo.cs
@@ -1,0 +1,202 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using MethodDB = System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<AnalyzeAsm.PositionInfo>>>;
+
+namespace AnalyzeAsm
+{
+    /// <summary>
+    ///     Represents the positions in file where the method is present.
+    /// </summary>
+    public class PositionInfo
+    {
+        public int s;
+        public int l;
+
+        public PositionInfo(int start, int length)
+        {
+            this.s = start;
+            this.l = length;
+        }
+
+        public override string ToString()
+        {
+            return $"{s} : {l}";
+        }
+    }
+
+    /// <summary>
+    ///     Index file that is serialized by the indexer.
+    /// </summary>
+    public class MethodIndex
+    {
+        public DateTime LastModifiedTimeOfExe = DateTime.MinValue;
+        public Dictionary<string, DateTime> LastModifiedTime = null;
+        public MethodDB MethodDatabase = null;
+        public static Dictionary<string, List<PositionInfo>> EmptyEntries = new Dictionary<string, List<PositionInfo>>();
+
+        public MethodIndex(DateTime lastModifiedTimeOfExe, Dictionary<string, DateTime> modifiedTimeInfo, MethodDB methodsInfo)
+        {
+            LastModifiedTimeOfExe = lastModifiedTimeOfExe;
+            LastModifiedTime = modifiedTimeInfo;
+            MethodDatabase = methodsInfo;
+        }
+
+        /// <summary>
+        ///     Search for occurances of <paramref name="methodName"/>.
+        /// </summary>
+        /// <param name="methodName"></param>
+        /// <returns></returns>
+        internal Dictionary<string, List<PositionInfo>> GetOccurances(string methodName)
+        {
+            if (MethodDatabase.TryGetValue(methodName, out Dictionary<string, List<PositionInfo>> result))
+            {
+                return result;
+            }
+            return EmptyEntries;
+        }
+
+        /// <summary>
+        ///     Process each .dasm file and find positions for every assembly listing.
+        /// </summary>
+        /// <param name="fileName"></param>
+        internal void AddFile(string fileName)
+        {
+            LastModifiedTime[Path.GetFileName(fileName)] = File.GetLastWriteTimeUtc(fileName);
+
+            string line, methodName = null;
+            int lineNumber = 1, startLineNumber = 0;
+            using FileStream fs = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using BufferedStream bs = new BufferedStream(fs);
+            using StreamReader sr = new StreamReader(bs);
+            while ((line = sr.ReadLine()) != null)
+            {
+                if (line.StartsWith("; Assembly listing for method"))
+                {
+                    if (startLineNumber > 0)
+                    {
+                        if (!MethodDatabase.TryGetValue(methodName, out Dictionary<string, List<PositionInfo>> fileList))
+                        {
+                            fileList = new Dictionary<string, List<PositionInfo>>();
+                            MethodDatabase[methodName] = fileList;
+                        }
+                        if (!fileList.TryGetValue(fileName, out List<PositionInfo> positions))
+                        {
+                            positions = new List<PositionInfo>();
+                            fileList[fileName] = positions;
+                        }
+
+                        MethodDatabase[methodName][fileName].Add(new PositionInfo(startLineNumber, lineNumber - startLineNumber));
+                    }
+
+                    methodName = line.Replace("; Assembly listing for method ", string.Empty);
+                    startLineNumber = lineNumber;
+                }
+                lineNumber++;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Indexer that creates .index file for all methods and their timestamps.
+    /// </summary>
+    internal class Indexer
+    {
+        private static Stopwatch stopWatch = new Stopwatch();
+        private static readonly string indexFileName = ".index";
+
+        /// <summary>
+        ///     Creates .index file based on .dasm files present in <paramref name="folderPath"/>.
+        /// </summary>
+        /// <param name="folderPath"></param>
+        private static MethodIndex CreateIndex(string folderPath)
+        {
+            if (!Directory.Exists(folderPath))
+            {
+                throw new DirectoryNotFoundException($"Direction {folderPath} not found.");
+            }
+
+            stopWatch.Restart();
+
+            var timestamps = new Dictionary<string, DateTime>();
+            var methodDatabase = new MethodDB();
+            MethodIndex index = new MethodIndex(File.GetLastWriteTimeUtc(Assembly.GetExecutingAssembly().Location), timestamps, methodDatabase);
+
+            var dasmFiles = Directory.GetFiles(folderPath, "*.dasm", SearchOption.TopDirectoryOnly);
+            foreach (var dasmFile in dasmFiles)
+            {
+                index.AddFile(dasmFile);
+            }
+
+            string contents = JsonConvert.SerializeObject(index);
+            File.WriteAllText(Path.Combine(folderPath, indexFileName), contents);
+
+            stopWatch.Stop();
+            Console.WriteLine($"Index created in {stopWatch.Elapsed.TotalSeconds} secs.");
+            return index;
+        }
+
+        /// <summary>
+        ///     Checks if .index file should be created or not.
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <param name="doExeTimeStampCheck">Should exe timestamp check done or not.</param>
+        private static bool TryGetIndex(string folderPath, out MethodIndex index, bool doExeTimeStampCheck = true)
+        {
+            index = null;
+            string indexFilePath = Path.Combine(folderPath, indexFileName);
+
+            if (!File.Exists(indexFilePath))
+            {
+                return false;
+            }
+
+            index = JsonConvert.DeserializeObject<MethodIndex>(File.ReadAllText(indexFilePath));
+            var expectedExeTimeStamp = index.LastModifiedTimeOfExe;
+            var actualExeTimeStamp = File.GetLastWriteTimeUtc(Assembly.GetExecutingAssembly().Location);
+
+            // If exe timestamp check should be done
+            if (doExeTimeStampCheck && expectedExeTimeStamp != actualExeTimeStamp)
+            {
+                return false;
+            }
+
+            var timestamps = index.LastModifiedTime;
+            foreach (var fileEntry in timestamps)
+            {
+                string fullFilePath = Path.Combine(folderPath, fileEntry.Key);
+
+                if (!File.Exists(fullFilePath) || fileEntry.Value != File.GetLastWriteTimeUtc(fullFilePath))
+                {
+                    // recreate index if dasm files timestamp don't match
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Loads the index metadata and verifies the timestamps of .dasm files as well as exe.
+        ///     If they match, just returns otherwise creates .index file.
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <param name="doExeTimeStampCheck">If timestamp check of exe to be done.</param>
+        public static MethodIndex GetIndex(string folderPath, bool doExeTimeStampCheck = false)
+        {
+            MethodIndex index;
+            if (!TryGetIndex(folderPath, out index, doExeTimeStampCheck))
+            {
+                index = CreateIndex(folderPath);
+            }
+            return index;
+        }
+    }
+}

--- a/src/AnalyzeAsm/Program.cs
+++ b/src/AnalyzeAsm/Program.cs
@@ -73,7 +73,7 @@ namespace AnalyzeAsm
             //PrintAssembly(x64File, args[0]);
             //}
             //CalculateTotalSize();
-            Distribution();
+            //Distribution();
             //GetLoadStores();
             //OptimizeDmbs();
             //FindStrGroups_wzr($@"{workingFolder}\str_str_wzr_to_str_xzr-1.asm");
@@ -95,9 +95,60 @@ namespace AnalyzeAsm
             //RedundantMovs1($@"{workingFolder}\redundant-mov-1.asm");
             //RedundantMovs2($@"{workingFolder}\redundant-mov-2.asm");
             //RedundantMovs3($@"{workingFolder}\redundant-mov-3.asm");
+            //PrintAssembly(armFile, "System.Linq.Expressions.Interpreter.ActionCallInstruction:Run(System.Linq.Expressions.Interpreter.InterpretedFrame):int:this");
+            PrintAssembly();
+            // No index
+            //var dasmFiles = Directory.GetFiles(armFolderForJit, "*.dasm", SearchOption.TopDirectoryOnly);
+            //foreach (var dasmFile in dasmFiles)
+            //{
+            //    PrintAssembly(dasmFile, "System.Linq.Expressions.Interpreter.ActionCallInstruction:Run(System.Linq.Expressions.Interpreter.InterpretedFrame):int:this");
+            //}
 
             watch.Stop();
             Console.WriteLine($"Hello World! took {watch.Elapsed.TotalSeconds} secs.");
+        }
+
+        static void PrintAssembly()
+        {
+            MethodIndex[] indexes = new MethodIndex[2];
+            indexes[0] = Indexer.GetIndex(armFolderForJit);
+            indexes[1] = Indexer.GetIndex(x64FolderForJit);
+
+            while (true)
+            {
+                Console.Write(">>");
+                string methodName = Console.ReadLine().Trim();
+                if (string.IsNullOrEmpty(methodName))
+                {
+                    continue;
+                }
+
+                foreach (var index in indexes)
+                {
+                    var occurances = index.GetOccurances(methodName);
+
+                    foreach (var occurance in occurances)
+                    {
+                        string fileName = occurance.Key;
+                        var positions = occurance.Value;
+
+                        var lines = File.ReadLines(fileName);
+                        foreach (var position in positions)
+                        {
+                            var contents = lines.Skip(position.s - 1).Take(position.l);
+                            foreach (var line in contents)
+                            {
+                                Console.WriteLine(line);
+                            }
+                        }
+                    }
+                    if (occurances.Count > 0)
+                    {
+                        Console.WriteLine("****************************************************");
+                        Console.WriteLine("****************************************************");
+                    }
+                }
+            }
         }
 
         static void PrintAssembly(string fileName, string name)

--- a/src/AnalyzeAsm/README.md
+++ b/src/AnalyzeAsm/README.md
@@ -72,6 +72,14 @@ add x2, x2, #4
 ldr x0, [x2, #4]!
 ```
 
+`FindPreIndexAddrMode2()` finds patterns:
+```asm
+add x2, x2, #4
+ldr x0, [x2, #4]
+;becomes
+ldr x0, [x2, #4]!
+```
+
 `RedundantMovs1()` finds patterns:
 ```asm
 mov x0, x0


### PR DESCRIPTION
* Added following analyzer:
  *  FindPreIndexAddrMode
  * Find ldr followed by str or vice-versa

* Added ability to find assembly method in output produced by jit-analyze. It creates a `.index` file containing method names along with start/end line of that method in all the files. Subsequent lookups are quick. Again the folder paths are hardcoded but can be easily made to be passed via command line.