### PR TITLE
Undo a non-determinism workaround.

### DIFF
--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -1326,15 +1326,6 @@ class PrepareMethodinator
         return 101;
     }
 
-    private static void EnsureGetCurrentProcessorIdIsDeterministic()
-    {
-#if NETCOREAPP
-        var type = typeof(System.Threading.Thread);
-        var field = type.GetField("s_isProcessorNumberReallyFast", BindingFlags.NonPublic | BindingFlags.Static);
-        field.SetValue(null, true);
-#endif
-    }
-
     private static void EnsureGen2GcCallbackFuncIsJitted()
     {
 #if NETCOREAPP
@@ -1354,13 +1345,6 @@ class PrepareMethodinator
         {
             return Usage();
         }
-
-        // System.Threading.Thread.s_isProcessorNumberReallyFast can have different
-        // values on two invocations of the process on the same machine. That causes
-        // non-determinism in generated code in methods inlining System.Threading.Thread.GetCurrentProcessorId().
-        // This methods uses reflection to set the value of System.Threading.Thread.s_isProcessorNumberReallyFast
-        // to true.
-        EnsureGetCurrentProcessorIdIsDeterministic();
 
         // TlsOverPerCoreLockedStacksArrayPool.Return registers Gen2GcCallbackFunc on Gen2GcCallback.
         // Gen2GcCallbackFunc is then called from Gen2GcCallback finalizer after a gc.


### PR DESCRIPTION
I added a workaround for disassembly non-determinism in #255.
See #255 for details of what causes the non-determinism.
It turns out it relied on a reflection hole that allowed
init-only static fields to be modified after static constructor has
been called. That hole was fixed in https://github.com/dotnet/runtime/pull/37849
so the workaround is no longer valid and causes an exception from pmi.

I don't see a way to work around the non-determinism without changing
framework code so for now I'm just reverting the workaround. Unfortunately, that
means that we can get non-deterministic disassembly for any method that inlines
System.Threading.Thread.GetCurrentProcessorId.

Fixes #271.