### PR TITLE
Add instruction count, variable debug info metrics

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -531,7 +531,7 @@ namespace ManagedCodeGen
                                         Double.Parse(dataMatch2.Groups[2].Value) : 0,
                                      // Use function index only from non-data lines (the name line)
                                      functionOffset = dataMatch.Success ?
-                                        0 : x.index
+                                        -1 : x.index
                                  };
                              })
                              .GroupBy(x => x.name)
@@ -543,7 +543,7 @@ namespace ManagedCodeGen
                                      functionCount = x.Select(z => z).Where(z => z.totalBytes == 0).Count(),
                                      // for all non-zero function offsets create list.
                                      functionOffsets = x.Select(z => z)
-                                                    .Where(z => z.functionOffset != 0)
+                                                    .Where(z => z.functionOffset != -1)
                                                     .Select(z => z.functionOffset).ToList()
                                  };
 

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -177,7 +177,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("t|tag", ref _tag, "Name of root in output directory. Allows for many sets of output.");
                     syntax.DefineOption("c|corelib", ref _corelib, "Diff System.Private.CoreLib.dll.");
                     syntax.DefineOption("f|frameworks", ref _frameworks, "Diff frameworks.");
-                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount");
+                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, DebugClauseCount, DebugVarCount");
                     syntax.DefineOption("benchmarks", ref _benchmarks, "Diff core benchmarks.");
                     syntax.DefineOption("tests", ref _tests, "Diff all tests.");
                     syntax.DefineOption("gcinfo", ref _gcinfo, "Add GC info to the disasm output.");

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -177,7 +177,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("t|tag", ref _tag, "Name of root in output directory. Allows for many sets of output.");
                     syntax.DefineOption("c|corelib", ref _corelib, "Diff System.Private.CoreLib.dll.");
                     syntax.DefineOption("f|frameworks", ref _frameworks, "Diff frameworks.");
-                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize");
+                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount");
                     syntax.DefineOption("benchmarks", ref _benchmarks, "Diff core benchmarks.");
                     syntax.DefineOption("tests", ref _tests, "Diff all tests.");
                     syntax.DefineOption("gcinfo", ref _gcinfo, "Add GC info to the disasm output.");


### PR DESCRIPTION
Adds "Instruction Count" metrics in `jit-analyze` and `jit-diff`

Update: Also includes Variable debug info metrics from #281

Fixes #266 