### PR TITLE
Rename protononjit.dll to clrjit_win_arm64_x64.dll

### DIFF
--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -193,7 +193,7 @@ The "jit-diff diff" command has this help message:
         --diff_root <arg>     Path to root of diff dotnet/coreclr repo.
         --arch <arg>          Architecture to diff (x86, x64).
         --build <arg>         Build flavor to diff (Checked, Debug).
-        --altjit <arg>        If set, the name of the altjit to use (e.g., protononjit.dll).
+        --altjit <arg>        If set, the name of the altjit to use (e.g., clrjit_win_arm64_x64.dll).
         --pmi                 Generate diffs via jitting instead of running crossgen
         --assembly <arg>      Look at diffs for methods in the specified assembly
     
@@ -505,7 +505,7 @@ Sample help command line:
                 <assembly>...
 
     --altjit <arg>             If set, the name of the altjit to use
-                               (e.g., protononjit.dll).
+                               (e.g., clrjit_win_arm64_x64.dll).
     -c, --crossgen <arg>       The crossgen or crossgen2 compiler exe.
     -j, --jit <arg>            The full path to the jit library.
     -o, --output <arg>         The output path.

--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -52,7 +52,7 @@ namespace ManagedCodeGen
         {
             _syntaxResult = ArgumentSyntax.Parse(args, syntax =>
             {
-                syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., protononjit.dll).");
+                syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., clrjit_win_arm64_x64.dll).");
                 syntax.DefineOption("c|corerun", ref _corerunExe, "The corerun compiler exe.");
                 syntax.DefineOption("j|jit", ref _jitPath, "The full path to the jit library.");
                 syntax.DefineOption("o|output", ref _rootPath, "The output path.");

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -62,7 +62,7 @@ namespace ManagedCodeGen
         {
             _syntaxResult = ArgumentSyntax.Parse(args, syntax =>
             {
-                syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., protononjit.dll).");
+                syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., clrjit_win_arm64_x64.dll).");
                 syntax.DefineOption("c|crossgen", ref _crossgenExe, "The crossgen or crossgen2 compiler exe.");
                 syntax.DefineOption("j|jit", ref _jitPath, "The full path to the jit library.");
                 syntax.DefineOption("o|output", ref _rootPath, "The output path.");

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -190,7 +190,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("diff_root", ref _diffRoot, "Path to root of diff dotnet/runtime repo.");
                     syntax.DefineOption("arch", ref _arch, "Architecture to diff (x86, x64).");
                     syntax.DefineOption("build", ref _build, "Build flavor to diff (Checked, Debug).");
-                    syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., protononjit.dll).");
+                    syntax.DefineOption("altjit", ref _altjit, "If set, the name of the altjit to use (e.g., clrjit_win_arm64_x64.dll).");
                     var pmiOption = syntax.DefineOption("pmi", ref _pmi, "Run asm diffs via pmi.");
                     syntax.DefineOption("cctors", ref _cctors, "With --pmi, jit and run cctors before jitting other methods");
                     syntax.DefineOptionList("assembly", ref _assemblyList, "Run asm diffs on a given set of assemblies. An individual item can be an assembly or a directory tree containing assemblies.");


### PR DESCRIPTION
Now that we have stopped producing `protononjit.dll` in https://github.com/dotnet/runtime/pull/41126, replace its reference with new name e.g. `clrjit_win_arm64_x64.dll`