### PR TITLE
Append random id to log files so they get ignored during git-diff

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -359,6 +359,7 @@ namespace ManagedCodeGen
             public bool doDebugDump = false;
             public bool verbose = false;
             private int _errorCount = 0;
+            private Random _rand = new Random();
 
             public int ErrorCount { get { return _errorCount; } }
 
@@ -573,7 +574,10 @@ namespace ManagedCodeGen
                         // Generate path to the output file
                         var assemblyFileName = Path.ChangeExtension(assembly.Name, ".dasm");
                         var dasmPath = Path.Combine(_rootPath, assembly.OutputPath, assemblyFileName);
-                        var logPath = Path.ChangeExtension(dasmPath, ".log");
+
+                        // Append a random id to the log files so they don't get picked up by "git diff"
+                        string randomId = _rand.Next(0, 5000).ToString();
+                        var logPath = Path.ChangeExtension(dasmPath, $".{randomId}.log");
 
                         PathUtility.EnsureParentDirectoryExists(dasmPath);
 

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -386,6 +386,7 @@ namespace ManagedCodeGen
             public bool verbose = false;
             private int _errorCount = 0;
             protected Dictionary<string, string> _environmentVariables;
+            protected Random _rand = new Random();
 
             public int ErrorCount { get { return _errorCount; } }
 
@@ -544,7 +545,9 @@ namespace ManagedCodeGen
 
                     if (_rootPath != null)
                     {
-                        var logPath = Path.ChangeExtension(dasmPath, ".log");
+                        // Append a random id to the log files so they don't get picked up by "git diff"
+                        string randomId = _rand.Next(0, 5000).ToString();
+                        var logPath = Path.ChangeExtension(dasmPath, $".{randomId}.log");
 
                         // Redirect stdout/stderr to log file and run command.
                         using (var outputStreamWriter = File.CreateText(logPath))


### PR DESCRIPTION
Today, when doing diff, we perform `git diff` on `base` and `diff`. These folders has `.dasm` as well as `.log` files. The `.log` files are comparable in size. For e.g., they are 520MB while `.dasm` files are 800MB. Once we do `git diff`, we then filter the diffs that are coming out of `.dasm` files. Thus, we unnecessarily spend time diffing the `.log` files. In https://github.com/dotnet/jitutils/pull/284, I added a way to ignore files if they are not present in both the folders. With that, I propose to add a random ID to the log files so they automatically get ignored when doing `git diff` and thus saving some time.