### PR TITLE
Replace Dotnet.Cli.Utils.Command with System.Diagnostic.Process

### DIFF
--- a/src/cijobs/cijobs.cs
+++ b/src/cijobs/cijobs.cs
@@ -33,10 +33,7 @@ using System.CommandLine;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.IO.Compression;
-//using Microsoft.DotNet.Cli.Utils;
-//using Microsoft.DotNet.Tools.Common;
 using Newtonsoft.Json;
-//using Newtonsoft.Json.Linq;
 
 namespace ManagedCodeGen
 {

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -9,8 +9,6 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Common;
 using Newtonsoft.Json;
 using System.Text;
 using System.Runtime.CompilerServices;
@@ -947,11 +945,6 @@ namespace ManagedCodeGen
             }
         }
 
-        class ScriptResolverPolicyWrapper : ICommandResolverPolicy
-        {
-            public CompositeCommandResolver CreateCommandResolver() => ScriptCommandResolverPolicy.Create();
-        }
-
         // There are files with diffs. Build up a dictionary mapping base file name to net text diff count.
         // Use "git diff" to do the analysis for us, then parse that output.
         //
@@ -978,22 +971,8 @@ namespace ManagedCodeGen
             commandArgs.Add("--numstat");
             commandArgs.Add(diffPath);
             commandArgs.Add(basePath);
-            Command diffCmd = null;
 
-            try
-            {
-                diffCmd = Command.Create(new ScriptResolverPolicyWrapper(), @"git", commandArgs);
-            }
-            catch (CommandUnknownException e)
-            {
-                Console.Error.WriteLine("\nError: git command not found!  Add git to the environment path.\n", e);
-                Environment.Exit(-1);
-            }
-
-            diffCmd.CaptureStdOut();
-            diffCmd.CaptureStdErr();
-
-            CommandResult result = diffCmd.Execute();
+            ProcessResult result = Utility.ExecuteProcess("git", commandArgs, true);
             Dictionary<string, int> fileToTextDiffCount = new Dictionary<string, int>();
 
             if (result.ExitCode != 0)

--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -569,12 +569,10 @@ namespace ManagedCodeGen
                         StringBuilder output = new StringBuilder();
                         if (!string.IsNullOrEmpty(result.StdOut))
                         {
-                            output.AppendLine("Standard output:");
                             output.AppendLine(result.StdOut);
                         }
-                        if (!string.IsNullOrEmpty(result.StdErr))
+                        if (!string.IsNullOrEmpty(result.StdErr) && (result.StdOut != result.StdErr))
                         {
-                            output.AppendLine("Standard error:");
                             output.AppendLine(result.StdErr);
                         }
                         if (output.Length > 0)

--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -461,7 +461,7 @@ namespace ManagedCodeGen
                         _environmentVariables[varName] = varValue;
                         if (this.verbose)
                         {
-                            Console.WriteLine("Setting: {0}={1}", varName, varValue);
+                            Console.WriteLine("set {0}={1}", varName, varValue);
                         }
                     }
 

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -527,17 +527,17 @@ namespace ManagedCodeGen
                     if (_rootPath != null)
                     {
                         var logPath = Path.ChangeExtension(dasmPath, ".log");
-                        result = ExecuteProcess(commandArgs);
+                        result = ExecuteProcess(commandArgs, true);
 
                         // Write stdout/stderr to log file.
                         StringBuilder output = new StringBuilder();
                         if (!string.IsNullOrEmpty(result.StdOut))
                         {
-                            output.AppendLine(result.StdOut);
+                            output.Append(result.StdOut);
                         }
                         if (!string.IsNullOrEmpty(result.StdErr) && (result.StdOut != result.StdErr))
                         {
-                            output.AppendLine(result.StdErr);
+                            output.Append(result.StdErr);
                         }
                         if (output.Length > 0)
                         {

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -27,8 +27,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Runtime.Loader;
 using System.Linq;
-using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Common;
+using System.Text;
 
 namespace ManagedCodeGen
 {
@@ -406,11 +405,6 @@ namespace ManagedCodeGen
                 this.verbose = config.DoVerboseOutput;
             }
 
-            class ScriptResolverPolicyWrapper : ICommandResolverPolicy
-            {
-                public CompositeCommandResolver CreateCommandResolver() => ScriptCommandResolverPolicy.Create();
-            }
-
             public void GenerateAsm()
             {
                 // Build a command per assembly to generate the asm output.
@@ -463,7 +457,7 @@ namespace ManagedCodeGen
                         nativeOutput = Path.Combine(_rootPath, assembly.OutputPath, assemblyNativeFileName);
                         mapOutput = Path.Combine(_rootPath, assembly.OutputPath, assemblyMapFileName);
 
-                        PathUtility.EnsureParentDirectoryExists(nativeOutput);
+                        Utility.EnsureParentDirectoryExists(nativeOutput);
 
                         AddOutputPathOption(commandArgs, nativeOutput);
                     }
@@ -518,21 +512,9 @@ namespace ManagedCodeGen
                         var assemblyFileName = Path.ChangeExtension(assembly.Name, ".dasm");
                         dasmPath = Path.Combine(_rootPath, assembly.OutputPath, assemblyFileName);
 
-                        PathUtility.EnsureParentDirectoryExists(dasmPath);
+                        Utility.EnsureParentDirectoryExists(dasmPath);
 
                         AddEnvironmentVariable("COMPlus_JitStdOutFile", dasmPath);
-                    }
-
-                    Command generateCmd = null;
-
-                    try
-                    {
-                        generateCmd = CreateCommand(new ScriptResolverPolicyWrapper(), commandArgs);
-                    }
-                    catch (CommandUnknownException e)
-                    {
-                        Console.Error.WriteLine("\nError: {0} command not found!\n", e);
-                        Environment.Exit(-1);
                     }
 
                     if (this.verbose)
@@ -540,19 +522,28 @@ namespace ManagedCodeGen
                         Console.WriteLine("Running: {0} {1}", _executablePath, String.Join(" ", commandArgs));
                     }
 
-                    CommandResult result;
+                    ProcessResult result;
 
                     if (_rootPath != null)
                     {
                         var logPath = Path.ChangeExtension(dasmPath, ".log");
+                        result = ExecuteProcess(commandArgs);
 
-                        // Redirect stdout/stderr to log file and run command.
-                        using (var outputStreamWriter = File.CreateText(logPath))
+                        // Write stdout/stderr to log file.
+                        StringBuilder output = new StringBuilder();
+                        if (!string.IsNullOrEmpty(result.StdOut))
                         {
-                            // Forward output and error to file.
-                            generateCmd.ForwardStdOut(outputStreamWriter);
-                            generateCmd.ForwardStdErr(outputStreamWriter);
-                            result = generateCmd.Execute();
+                            output.AppendLine("Standard output:");
+                            output.AppendLine(result.StdOut);
+                        }
+                        if (!string.IsNullOrEmpty(result.StdErr))
+                        {
+                            output.AppendLine("Standard error:");
+                            output.AppendLine(result.StdErr);
+                        }
+                        if (output.Length > 0)
+                        {
+                            File.WriteAllText(logPath, output.ToString());
                         }
 
                         bool hasOutput = true;
@@ -587,9 +578,7 @@ namespace ManagedCodeGen
                     else
                     {
                         // By default forward to output to stdout/stderr.
-                        generateCmd.ForwardStdOut();
-                        generateCmd.ForwardStdErr();
-                        result = generateCmd.Execute();
+                        result = ExecuteProcess(commandArgs);
 
                         if (result.ExitCode != 0)
                         {
@@ -635,7 +624,7 @@ namespace ManagedCodeGen
 
             abstract protected void AddOptimizationOption(List<string> commandArgs);
 
-            abstract protected Command CreateCommand(ICommandResolverPolicy resolverPolicy, List<string> commandArgs);
+            abstract protected ProcessResult ExecuteProcess(List<string> commandArgs, bool capture = false);
         }
 
         sealed private class CrossgenDisasmEngine : DisasmEngine
@@ -677,14 +666,9 @@ namespace ManagedCodeGen
             {
             }
 
-            override protected Command CreateCommand(ICommandResolverPolicy resolverPolicy, List<string> commandArgs)
+            override protected ProcessResult ExecuteProcess(List<string> commandArgs, bool capture)
             {
-                Command command = Command.Create(resolverPolicy, _executablePath, commandArgs);
-                foreach (var envVar in _environmentVariables)
-                {
-                    command.EnvironmentVariable(envVar.Key, envVar.Value);
-                }
-                return command;
+                return Utility.ExecuteProcess(_executablePath, commandArgs, capture, environmentVariables: _environmentVariables);
             }
         }
 
@@ -726,7 +710,7 @@ namespace ManagedCodeGen
                 commandArgs.Add("--optimize");
             }
 
-            override protected Command CreateCommand(ICommandResolverPolicy resolverPolicy, List<string> commandArgs)
+            override protected ProcessResult ExecuteProcess(List<string> commandArgs, bool capture)
             {
                 foreach (var envVar in _environmentVariables)
                 {
@@ -734,8 +718,7 @@ namespace ManagedCodeGen
                     string complusPrefix = "COMPlus_";
                     commandArgs.Add(String.Format("{0}={1}", envVar.Key.Substring(complusPrefix.Length), envVar.Value));
                 }
-                Command command = Command.Create(resolverPolicy, _executablePath, commandArgs);
-                return command;
+                return Utility.ExecuteProcess(_executablePath, commandArgs, capture);
             }
         }
     }

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -533,12 +533,10 @@ namespace ManagedCodeGen
                         StringBuilder output = new StringBuilder();
                         if (!string.IsNullOrEmpty(result.StdOut))
                         {
-                            output.AppendLine("Standard output:");
                             output.AppendLine(result.StdOut);
                         }
-                        if (!string.IsNullOrEmpty(result.StdErr))
+                        if (!string.IsNullOrEmpty(result.StdErr) && (result.StdOut != result.StdErr))
                         {
-                            output.AppendLine("Standard error:");
                             output.AppendLine(result.StdErr);
                         }
                         if (output.Length > 0)

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -606,7 +606,7 @@ namespace ManagedCodeGen
                 _environmentVariables[varName] = varValue;
                 if (this.verbose)
                 {
-                    Console.WriteLine("Setting: {0}={1}", varName, varValue);
+                    Console.WriteLine("set {0}={1}", varName, varValue);
                 }
             }
 

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -332,7 +332,12 @@ namespace ManagedCodeGen
                 List<AssemblyInfo> assemblyWorkList = GenerateAssemblyWorklist(config);
                 DasmResult dasmResult = diffTool.RunDasmTool(commandArgs, assemblyWorkList);
                 Console.WriteLine($"Completed {diffString} in {(DateTime.Now - startTime).TotalSeconds:F2}s");
-                Console.WriteLine($"Diffs (if any) can be viewed by comparing: {Path.Combine(config.OutputPath, "base")} {Path.Combine(config.OutputPath, "diff")}");
+                string basePath = Path.Combine(config.OutputPath, "base");
+                string diffPath = Path.Combine(config.OutputPath, "diff");
+                Console.WriteLine($"Diffs (if any) can be viewed by comparing: {basePath} {diffPath}");
+                Console.WriteLine("");
+                Console.WriteLine($"git diff --no-index --diff-filter=M --exit-code --numstat {diffPath} {basePath}");
+                Console.WriteLine("");
 
                 // Analyze completed run.
 

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -7,7 +7,6 @@ using System.CommandLine;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.DotNet.Cli.Utils;
 using System.Threading.Tasks;
 
 namespace ManagedCodeGen
@@ -150,7 +149,7 @@ namespace ManagedCodeGen
                 {
                     Console.WriteLine("Dasm command: {0}", command);
                 }
-                CommandResult result = Utility.TryCommand(CommandName, item.DasmArgs);
+                ProcessResult result = Utility.ExecuteProcess(CommandName, item.DasmArgs);
                 if (result.ExitCode != 0)
                 {
                     Console.Error.WriteLine("Dasm command \"{0}\" returned with {1} failures", command, result.ExitCode);
@@ -369,7 +368,7 @@ namespace ManagedCodeGen
 
                     Console.WriteLine($"Analyzing {config.Metric} diffs...");
                     startTime = DateTime.Now;
-                    CommandResult analyzeResult = Utility.TryCommand(s_analysisTool, analysisArgs);
+                    ProcessResult analyzeResult = Utility.ExecuteProcess(s_analysisTool, analysisArgs);
                     Console.WriteLine($"Completed analysis in {(DateTime.Now - startTime).TotalSeconds:F2}s");
                 }
 

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -352,7 +352,7 @@ namespace ManagedCodeGen
                     analysisArgs.Add("--note");
 
                     string jitName = config.AltJit ?? "default jit";
-                    analysisArgs.Add($"{diffString} for {config.Arch} {jitName}");
+                    analysisArgs.Add($"\"{diffString} for {config.Arch} {jitName}\"");
 
                     if (config.tsv)
                     {

--- a/src/jit-diff/install.cs
+++ b/src/jit-diff/install.cs
@@ -3,19 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-//using System.Diagnostics;
 using System.CommandLine;
 using System.IO;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Linq;
-using Microsoft.DotNet.Cli.Utils;
-//using Microsoft.DotNet.Tools.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-//using System.Collections.Concurrent;
-//using System.Threading.Tasks;
-//using System.Runtime.InteropServices;
 
 namespace ManagedCodeGen
 {
@@ -90,7 +84,7 @@ namespace ManagedCodeGen
                 Console.WriteLine("Command: {0} {1}", "cijobs", String.Join(" ", cijobsArgs));
             }
 
-            CommandResult result = Utility.TryCommand("cijobs", cijobsArgs);
+            ProcessResult result = Utility.ExecuteProcess("cijobs", cijobsArgs);
 
             if (result.ExitCode != 0)
             {

--- a/src/jit-diff/uninstall.cs
+++ b/src/jit-diff/uninstall.cs
@@ -3,19 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-//using System.Diagnostics;
 using System.CommandLine;
 using System.IO;
-//using System.Collections.Generic;
-//using System.Text.RegularExpressions;
 using System.Linq;
-//using Microsoft.DotNet.Cli.Utils;
-//using Microsoft.DotNet.Tools.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-//using System.Collections.Concurrent;
-//using System.Threading.Tasks;
-//using System.Runtime.InteropServices;
 
 namespace ManagedCodeGen
 {

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -17,8 +17,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Linq;
-using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -87,7 +85,7 @@ namespace ManagedCodeGen
                     Console.WriteLine("Running: {0} {1}", "dotnet", String.Join(" ", commandArgs));
                 }
 
-                CommandResult result = Utility.TryCommand("dotnet", commandArgs, true);
+                ProcessResult result = Utility.ExecuteProcess("dotnet", commandArgs, true);
 
                 if (result.ExitCode != 0)
                 {
@@ -239,7 +237,7 @@ namespace ManagedCodeGen
                                 Console.WriteLine("Running: {0} {1}", buildPath, String.Join(" ", commandArgs));
                             }
 
-                            CommandResult result = Utility.TryCommand(buildPath, commandArgs, !_verbose, _rootPath);
+                            ProcessResult result = Utility.ExecuteProcess(buildPath, commandArgs, !_verbose, _rootPath);
 
                             if (result.ExitCode != 0)
                             {
@@ -271,7 +269,7 @@ namespace ManagedCodeGen
                                 Console.WriteLine("Running: {0} {1}", buildPath, String.Join(" ", commandArgs));
                             }
 
-                            CommandResult result = Utility.TryCommand(buildPath, commandArgs, true, _rootPath);
+                            ProcessResult result = Utility.ExecuteProcess(buildPath, commandArgs, true, _rootPath);
 
                             if (result.ExitCode != 0)
                             {
@@ -641,7 +639,7 @@ namespace ManagedCodeGen
                     Console.WriteLine("Running: {0} {1}", "clang-tidy", String.Join(" ", commandArgs));
                 }
 
-                CommandResult result = Utility.TryCommand("clang-tidy", commandArgs, true);
+                ProcessResult result = Utility.ExecuteProcess("clang-tidy", commandArgs, true);
 
                 if (!fix && (result.StdOut.Contains("warning:") || (!ignoreErrors && (result.StdOut.Contains("error:") || result.StdOut.Contains("Error")))))
                 {
@@ -690,7 +688,7 @@ namespace ManagedCodeGen
                         Console.WriteLine("Running: {0} {1}", "clang-format", String.Join(" ", commandArgs));
                     }
 
-                    CommandResult result = Utility.TryCommand("clang-format", commandArgs, true);
+                    ProcessResult result = Utility.ExecuteProcess("clang-format", commandArgs, true);
 
                     if (result.StdOut.Contains("<replacement ") && !fix)
                     {

--- a/src/jit-include.props
+++ b/src/jit-include.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170320-1" />
   </ItemGroup>
 

--- a/src/util/util.cs
+++ b/src/util/util.cs
@@ -241,11 +241,11 @@ namespace ManagedCodeGen
 
                 if (!string.IsNullOrEmpty(stdout))
                 {
-                    Console.WriteLine(stdout);
+                    Console.Write(stdout);
                 }
                 if (!string.IsNullOrEmpty(stderr) && (stdout != stderr))
                 {
-                    Console.WriteLine(stderr);
+                    Console.Write(stderr);
                 }
             }
 


### PR DESCRIPTION
- Replaced `Dotnet.Cli.Utils.Command` with `System.Diagnostic.Process` which is more robust and allow us to better handle process spawning mechanism.
- Print the `git diff` command to fix #92 
- Switch to `System.Diagnostic.Process` to fix #175.
- Add cancellation mechanism that will kill all the process and child process the given jitutil has spawned. Fixes #151 .
- Print the environment variables that fixes #141.