### PR TITLE
CoreDisTools on Arm

### DIFF
--- a/build-coredistools.cmd
+++ b/build-coredistools.cmd
@@ -8,12 +8,16 @@ set TargetOSArchitecture=%1
 
 if /i "%TargetOSArchitecture%" == "windows-arm" (
     set GeneratorPlatform=ARM
+    set LLVMHostTriple=arm-pc-windows-msvc
 ) else if /i "%TargetOSArchitecture%" == "windows-arm64" (
     set GeneratorPlatform=ARM64
+    set LLVMHostTriple=aarch64-pc-windows-msvc
 ) else if /i "%TargetOSArchitecture%" == "windows-x64" (
     set GeneratorPlatform=x64
+    set LLVMHostTriple=x86_64-pc-windows-msvc
 ) else if /i "%TargetOSArchitecture%" == "windows-x86" (
     set GeneratorPlatform=Win32
+    set LLVMHostTriple=i686-pc-windows-msvc
 ) else (
     echo "Unknown target OS and architecture: %TargetOSArchitecture%"
     exit /b 1
@@ -42,6 +46,7 @@ cmake.exe ^
     -DCMAKE_INSTALL_PREFIX="%RootDirectory%\" ^
     -DLLVM_EXTERNAL_PROJECTS=coredistools ^
     -DLLVM_EXTERNAL_COREDISTOOLS_SOURCE_DIR="%SourcesDirectory%\coredistools" ^
+    -DLLVM_HOST_TRIPLE=%LLVMHostTriple% ^
     -DLLVM_TABLEGEN="%LLVMTableGen%" ^
     -DLLVM_TARGETS_TO_BUILD=AArch64;ARM;X86 ^
     -DLLVM_TOOL_COREDISTOOLS_BUILD=ON ^

--- a/build-coredistools.cmd
+++ b/build-coredistools.cmd
@@ -8,6 +8,7 @@ set TargetOSArchitecture=%1
 
 if /i "%TargetOSArchitecture%" == "windows-arm" (
     set GeneratorPlatform=ARM
+    set LLVMDefaultTargetTriple=thumbv7-pc-windows-msvc
     set LLVMHostTriple=arm-pc-windows-msvc
 ) else if /i "%TargetOSArchitecture%" == "windows-arm64" (
     set GeneratorPlatform=ARM64
@@ -21,6 +22,10 @@ if /i "%TargetOSArchitecture%" == "windows-arm" (
 ) else (
     echo "Unknown target OS and architecture: %TargetOSArchitecture%"
     exit /b 1
+)
+
+if not defined LLVMDefaultTargetTriple (
+    set LLVMDefaultTargetTriple=%LLVMHostTriple%
 )
 
 where /q llvm-tblgen.exe
@@ -44,6 +49,7 @@ cmake.exe ^
     -G "Visual Studio 16 2019" ^
     -A %GeneratorPlatform% ^
     -DCMAKE_INSTALL_PREFIX="%RootDirectory%\" ^
+    -DLLVM_DEFAULT_TARGET_TRIPLE=%LLVMDefaultTargetTriple% ^
     -DLLVM_EXTERNAL_PROJECTS=coredistools ^
     -DLLVM_EXTERNAL_COREDISTOOLS_SOURCE_DIR="%SourcesDirectory%\coredistools" ^
     -DLLVM_HOST_TRIPLE=%LLVMHostTriple% ^

--- a/build-coredistools.cmd
+++ b/build-coredistools.cmd
@@ -60,6 +60,8 @@ cmake.exe ^
     -DLLVM_TABLEGEN="%LLVMTableGen%" ^
     -DLLVM_TARGETS_TO_BUILD=%LLVMTargetsToBuild% ^
     -DLLVM_TOOL_COREDISTOOLS_BUILD=ON ^
+    -DLLVM_USE_CRT_DEBUG=MTd ^
+    -DLLVM_USE_CRT_RELEASE=MT ^
     "%SourcesDirectory%\llvm-project\llvm"
 
 popd

--- a/build-coredistools.cmd
+++ b/build-coredistools.cmd
@@ -10,15 +10,19 @@ if /i "%TargetOSArchitecture%" == "windows-arm" (
     set GeneratorPlatform=ARM
     set LLVMDefaultTargetTriple=thumbv7-pc-windows-msvc
     set LLVMHostTriple=arm-pc-windows-msvc
+    set LLVMTargetsToBuild=ARM
 ) else if /i "%TargetOSArchitecture%" == "windows-arm64" (
     set GeneratorPlatform=ARM64
     set LLVMHostTriple=aarch64-pc-windows-msvc
+    set LLVMTargetsToBuild=AArch64
 ) else if /i "%TargetOSArchitecture%" == "windows-x64" (
     set GeneratorPlatform=x64
     set LLVMHostTriple=x86_64-pc-windows-msvc
+    set LLVMTargetsToBuild=AArch64;X86
 ) else if /i "%TargetOSArchitecture%" == "windows-x86" (
     set GeneratorPlatform=Win32
     set LLVMHostTriple=i686-pc-windows-msvc
+    set LLVMTargetsToBuild=ARM;X86
 ) else (
     echo "Unknown target OS and architecture: %TargetOSArchitecture%"
     exit /b 1
@@ -54,7 +58,7 @@ cmake.exe ^
     -DLLVM_EXTERNAL_COREDISTOOLS_SOURCE_DIR="%SourcesDirectory%\coredistools" ^
     -DLLVM_HOST_TRIPLE=%LLVMHostTriple% ^
     -DLLVM_TABLEGEN="%LLVMTableGen%" ^
-    -DLLVM_TARGETS_TO_BUILD=AArch64;ARM;X86 ^
+    -DLLVM_TARGETS_TO_BUILD=%LLVMTargetsToBuild% ^
     -DLLVM_TOOL_COREDISTOOLS_BUILD=ON ^
     "%SourcesDirectory%\llvm-project\llvm"
 

--- a/build-coredistools.sh
+++ b/build-coredistools.sh
@@ -9,16 +9,21 @@ CrossRootfsDirectory=$2
 case "$TargetOSArchitecture" in
     linux-arm)
         CrossCompiling=1
-        TargetTriple=arm-linux-gnueabihf
+        LLVMDefaultTargetTriple=thumbv7-linux-gnueabihf
+        LLVMHostTriple=arm-linux-gnueabihf
+        LLVMTargetsToBuild=ARM
         ;;
 
     linux-arm64)
         CrossCompiling=1
-        TargetTriple=aarch64-linux-gnu
+        LLVMDefaultTargetTriple=aarch64-linux-gnu
+        LLVMHostTriple=aarch64-linux-gnu
+        LLVMTargetsToBuild=AArch64
         ;;
 
     linux-x64|macos-x64)
         CrossCompiling=0
+        LLVMTargetsToBuild="AArch64;X86"
         ;;
 
     *)
@@ -43,17 +48,18 @@ if [ "$CrossCompiling" -eq 1 ]; then
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_CROSSCOMPILING=ON \
         -DCMAKE_C_COMPILER=$(which clang) \
-        -DCMAKE_C_FLAGS="-target $TargetTriple --sysroot=$CrossRootfsDirectory" \
+        -DCMAKE_C_FLAGS="-target $LLVMHostTriple --sysroot=$CrossRootfsDirectory" \
         -DCMAKE_CXX_COMPILER=$(which clang++) \
-        -DCMAKE_CXX_FLAGS="-target $TargetTriple --sysroot=$CrossRootfsDirectory" \
+        -DCMAKE_CXX_FLAGS="-target $LLVMHostTriple --sysroot=$CrossRootfsDirectory" \
         -DCMAKE_INCLUDE_PATH=$CrossRootfsDirectory/usr/include \
         -DCMAKE_INSTALL_PREFIX=$RootDirectory \
-        -DCMAKE_LIBRARY_PATH=$CrossRootfsDirectory/usr/lib/$TargetTriple \
+        -DCMAKE_LIBRARY_PATH=$CrossRootfsDirectory/usr/lib/$LLVMHostTriple \
+        -DLLVM_DEFAULT_TARGET_TRIPLE=$LLVMDefaultTargetTriple \
         -DLLVM_EXTERNAL_PROJECTS=coredistools \
         -DLLVM_EXTERNAL_COREDISTOOLS_SOURCE_DIR=$SourcesDirectory/coredistools \
-        -DLLVM_HOST_TRIPLE=$TargetTriple \
+        -DLLVM_HOST_TRIPLE=$LLVMHostTriple \
         -DLLVM_TABLEGEN=$(which llvm-tblgen) \
-        -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86" \
+        -DLLVM_TARGETS_TO_BUILD=$LLVMTargetsToBuild \
         -DLLVM_TOOL_COREDISTOOLS_BUILD=ON \
         $SourcesDirectory/llvm-project/llvm
 else

--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -183,6 +183,8 @@ public:
 protected:
   enum TargetArch TheTargetArch;
   const PrintControl *Print;
+  bool isThumb2MoveImmediateOpcode(unsigned int opcode) const;
+  bool isThumb2MoveTopOpcode(unsigned int opcode) const;
 
 private:
   bool setTarget();
@@ -209,6 +211,11 @@ private:
 
   static const int X86NumPrefixes = 19;
   static const OpcodeMap X86Prefix[X86NumPrefixes];
+
+  // The following constants is a workaround and the opcode numbers
+  // were copied from TableGen-erated lib/Target/ARM/ARMGenInstrInfo.inc
+  static const unsigned int Thumb2MoveImmediateOpcode = 3887; // Corresponds to t2MOVi16
+  static const unsigned int Thumb2MoveTopOpcode = 3885; // Correspond to t2MOVTi16
 };
 
 struct CorAsmDiff : public CorDisasm {
@@ -502,6 +509,14 @@ void CorDisasm::dumpBlock(const BlockInfo &Block) const {
     BIter.advance();
   }
   Print->Dump("-----------------------------------------------");
+}
+
+bool CorDisasm::isThumb2MoveImmediateOpcode(unsigned int Opcode) const {
+  return (Opcode == Thumb2MoveImmediateOpcode);
+}
+
+bool CorDisasm::isThumb2MoveTopOpcode(unsigned int Opcode) const {
+  return (Opcode == Thumb2MoveTopOpcode);
 }
 
 // Compares two code sections for syntactic equality. This is the core of the

--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -281,7 +281,7 @@ bool CorDisasm::setTarget() {
     break;
 
   case Target_Thumb:
-    TheTriple.setArch(Triple::thumb);
+    TheTriple.setArchName("thumbv7");
     break;
   case Target_Arm64:
     TheTriple.setArch(Triple::aarch64);

--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -490,6 +490,12 @@ void CorDisasm::dumpInstruction(const BlockIterator &BIter) const {
                              "                  "};
     OS << (Padding[(InstSize < 7) ? (7 - InstSize) : 0]);
   }
+  else if (TheTargetArch == Target_Thumb) {
+    // Thumb-2 encoding has 32-bit instructions and 16-bit instructions.
+    if (InstSize == 2) {
+      OS << "      ";
+    }
+  }
 
   IP->printInst(&BIter.Inst, OS, "", *STI);
   Print->Dump(OS.str().c_str());

--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -30,6 +30,7 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/DataTypes.h"
+#include <inttypes.h>
 #include <stdarg.h>
 
 #define DllInterfaceExporter
@@ -463,7 +464,7 @@ void CorDisasm::dumpInstruction(const BlockIterator &BIter) const {
   string buffer;
   raw_string_ostream OS(buffer);
 
-  OS << format("%8llx: ", BIter.Addr);
+  OS << format("%" PRIxPTR ": ", BIter.Addr);
   dumpBytes(ArrayRef<uint8_t>(BIter.Ptr, InstSize), OS);
 
   if ((TheTargetArch == Target_X86) || (TheTargetArch == Target_X64)) {
@@ -489,8 +490,8 @@ void CorDisasm::dumpBlock(const BlockInfo &Block) const {
   BlockIterator BIter(Block);
 
   Print->Dump("-----------------------------------------------");
-  Print->Dump("Block:   %s\nSize:    %lu\nAddress: %8llx\nCodePtr: %8llx",
-              BIter.Name, BIter.BlockSize, BIter.Addr, BIter.Ptr);
+  Print->Dump("Block:   %s\nSize:    %" PRIu64 "\nAddress: %" PRIxPTR "\nCodePtr: %" PRIxPTR,
+              BIter.Name, BIter.BlockSize, BIter.Addr, (uintptr_t)BIter.Ptr);
   Print->Dump("-----------------------------------------------");
 
   while (!BIter.isEmpty()) {
@@ -637,7 +638,7 @@ bool BlockIterator::isBitwiseEqual(const BlockIterator &BIter) const {
 
 bool CorAsmDiff::fail(const char *Mesg, const BlockIterator &Left,
                       const BlockIterator &Right) const {
-  Print->Log("%s @[%llx : %llx]", Mesg, Left.Addr, Right.Addr);
+  Print->Log("%s @[%" PRIxPTR " : %" PRIxPTR "]", Mesg, Left.Addr, Right.Addr);
   return false;
 }
 


### PR DESCRIPTION
This adds support for proper recognition of movw/movt instructions pairs on Arm in `CorAsmDiff::nearDiff`.
In a case when such instructions pairs are compared, their immediates should not be compared independently. Instead their values should be used to reconstruct a 32-bit value that is loaded into a register and these reconstructed value should be compared either for identity or equality (with a user defined `Comparator`). 

I tested this approach by 
1. **superpmi collect** on on windows-arm on framework libraries
2. **superpmi replay** on windows-arm 
3. **superpmi replay** on windows-x86 (with clrjit_win_arm_x86.dll jit)

In both 2 and 3 there were no cases of false positives diffs between baseline and compared jits. (If this algorithm is disabled, almost every method becomes different according to `CorAsmDiff::nearDiff` due to some immediates - either movt or movw having different values).

This PR also specifies `LLVM_DEFAULT_TARGET_TRIPLE` to be Thumb2 not Arm and decreases number of platforms supported by each flavor of coredistools.