### PR TITLE
CoreDisTools on Arm64

### DIFF
--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -354,6 +354,11 @@ bool CorDisasm::init() {
 
   string Mcpu;        // Not specifying any particular CPU type.
   string FeaturesStr; // No additional target specific attributes.
+
+  if (TheTargetArch == Target_Arm64) {
+    Mcpu = "cortex-a76";
+  }
+
   STI.reset(TheTarget->createMCSubtargetInfo(TargetTriple, Mcpu, FeaturesStr));
   if (!STI) {
     Print->Error("error: no subtarget info for target %s\n",


### PR DESCRIPTION
The small change is to enable additional Arm64 ISAs in the dissassembler. 
Without this change, for example, the superpmi would not be able to dissassemble a method containing `AESD` instruction.