### PR TITLE
Allow more supported target architectures for R2RDump

### DIFF
--- a/build-coredistools.cmd
+++ b/build-coredistools.cmd
@@ -2,24 +2,23 @@
 setlocal EnableDelayedExpansion EnableExtensions
 
 set TargetOSArchitecture=%1
+set LLVMTargetsToBuild=AArch64;ARM;X86
 
 if /i "%TargetOSArchitecture%" == "win-arm" (
     set GeneratorPlatform=ARM
     set LLVMDefaultTargetTriple=thumbv7-pc-windows-msvc
     set LLVMHostTriple=arm-pc-windows-msvc
-    set LLVMTargetsToBuild=ARM
+    set LLVMTargetsToBuild=AArch64;ARM
 ) else if /i "%TargetOSArchitecture%" == "win-arm64" (
     set GeneratorPlatform=ARM64
     set LLVMHostTriple=aarch64-pc-windows-msvc
-    set LLVMTargetsToBuild=AArch64
+    set LLVMTargetsToBuild=AArch64;ARM
 ) else if /i "%TargetOSArchitecture%" == "win-x64" (
     set GeneratorPlatform=x64
     set LLVMHostTriple=x86_64-pc-windows-msvc
-    set LLVMTargetsToBuild=AArch64;X86
 ) else if /i "%TargetOSArchitecture%" == "win-x86" (
     set GeneratorPlatform=Win32
     set LLVMHostTriple=i686-pc-windows-msvc
-    set LLVMTargetsToBuild=ARM;X86
 ) else (
     echo ERROR: Unknown target OS and architecture: %TargetOSArchitecture%
     exit /b 1

--- a/build-coredistools.sh
+++ b/build-coredistools.sh
@@ -8,19 +8,19 @@ case "$TargetOSArchitecture" in
         CrossCompiling=1
         LLVMDefaultTargetTriple=thumbv7-linux-gnueabihf
         LLVMHostTriple=arm-linux-gnueabihf
-        LLVMTargetsToBuild=ARM
+        LLVMTargetsToBuild="AArch64;ARM"
         ;;
 
     linux-arm64)
         CrossCompiling=1
         LLVMDefaultTargetTriple=aarch64-linux-gnu
         LLVMHostTriple=aarch64-linux-gnu
-        LLVMTargetsToBuild=AArch64
+        LLVMTargetsToBuild="AArch64;ARM"
         ;;
 
     linux-x64|osx-x64)
         CrossCompiling=0
-        LLVMTargetsToBuild="AArch64;X86"
+        LLVMTargetsToBuild="AArch64;ARM;X86"
         ;;
 
     *)

--- a/coredistools.yml
+++ b/coredistools.yml
@@ -6,6 +6,10 @@ pr:
     include:
     - eng/*
     - src/coredistools/*
+    - build-coredistools.cmd
+    - build-coredistools.sh
+    - build-tblgen.cmd
+    - pack-coredistools.cmd
 
 trigger:
   branches:
@@ -15,6 +19,10 @@ trigger:
     include:
     - eng/*
     - src/coredistools/*
+    - build-coredistools.cmd
+    - build-coredistools.sh
+    - build-tblgen.cmd
+    - pack-coredistools.cmd
 
 resources:
   containers:


### PR DESCRIPTION
Change the target architectures matrix for coredistools:
- win-x86, win-x64, linux-x64, osx-x64 supports X86, ARM and AArch64.
- win-arm, win-arm64, linux-arm, linux-arm64 supports ARM and AArch64.

With this change x86/x64 R2RDump can target all the platforms with one version of coredistools binaries.

I was not sure if is useful to enable X86 target support on Arm/Arm64 hosted coredistools, so I decided not to in order to have smaller coredistools binaries on these platforms.