### PR TITLE
Fix path problems so we can get diff working

### DIFF
--- a/src/jit-dasm-pmi/jit-dasm-pmi.cs
+++ b/src/jit-dasm-pmi/jit-dasm-pmi.cs
@@ -608,7 +608,7 @@ namespace ManagedCodeGen
                             }
                         }
 
-                        if (hasOutput && !File.Exists(dasmPath))
+                        if (hasOutput && File.Exists(logPath) && !File.Exists(dasmPath))
                         {
                             // Looks like the JIT does not support COMPlus_JitStdOutFile so
                             // the assembly output must be in the log file.

--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -566,7 +566,7 @@ namespace ManagedCodeGen
                             }
                         }
 
-                        if (hasOutput && !File.Exists(dasmPath))
+                        if (hasOutput && File.Exists(logPath) && !File.Exists(dasmPath))
                         {
                             // Looks like the JIT does not support COMPlus_JitStdOutFile so
                             // the assembly output must be in the log file.

--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -506,8 +506,8 @@ namespace ManagedCodeGen
             private static List<AssemblyInfo> IdentifyAssemblies(string basePath, string rootPath, Config config, bool recursive, string searchPattern)
             {
                 List<AssemblyInfo> assemblyInfoList = new List<AssemblyInfo>();
-                string fullBasePath = Path.GetFullPath(basePath);
-                string fullRootPath = Path.GetFullPath(rootPath);
+                string fullBasePath = Path.GetFullPath(basePath).TrimEnd(Path.DirectorySeparatorChar);
+                string fullRootPath = Path.GetFullPath(rootPath).TrimEnd(Path.DirectorySeparatorChar);
 
                 // Get files that could be assemblies, but discard currently ngen'd assemblies.
                 SearchOption searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;


### PR DESCRIPTION
- There was miscalculation happening if the `CORE_ROOT` ended with trailing `\`. Fixed it.
- Also, in https://github.com/dotnet/jitutils/pull/287, I changed the way log files were created. If there is no contents to dump, then we would skip creating the log files. However, I missed the check if we decide to move a log file. 

Fixes: #300 
