### PR TITLE
Remove explicit "src" level from source path construction

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -59,6 +59,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("o|os", ref _os, "The operating system of the build (options: Windows, OSX, Linux etc.)");
                     syntax.DefineOption("b|build", ref _build, "The build type of the build (options: Release, Checked, Debug)");
                     syntax.DefineOption("c|coreclr", ref _rootPath, "Full path to base runtime/src/coreclr directory");
+                    syntax.DefineOption("s|source-directory", ref _srcDirectory, "Source directory relative to coreclr root");
                     syntax.DefineOption("compile-commands", ref _compileCommands, "Full path to compile_commands.json");
                     syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
                     syntax.DefineOption("untidy", ref _untidy, "Do not run clang-tidy");

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -164,7 +164,7 @@ namespace ManagedCodeGen
                     {
                         Console.WriteLine("Formatting jit directory.");
                     }
-                    _srcDirectory = "src/jit";
+                    _srcDirectory = Path.Combine("src", "jit");
                 }
 
                 if (_projects.Count == 0 && _verbose)

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -164,7 +164,7 @@ namespace ManagedCodeGen
                     {
                         Console.WriteLine("Formatting jit directory.");
                     }
-                    _srcDirectory = "jit";
+                    _srcDirectory = "src/jit";
                 }
 
                 if (_projects.Count == 0 && _verbose)
@@ -408,7 +408,7 @@ namespace ManagedCodeGen
             if (config.Filenames.Count() == 0)
             {
                 // add all files to a list of files
-                foreach (string filename in Directory.GetFiles(Path.Combine(config.CoreCLRRoot, "src", config.SourceDirectory)))
+                foreach (string filename in Directory.GetFiles(Path.Combine(config.CoreCLRRoot, config.SourceDirectory)))
                 {
                     // if it's not a directory, add it to our list
                     if (!Directory.Exists(filename) && (filename.EndsWith(".cpp") || filename.EndsWith(".h") || filename.EndsWith(".hpp")))
@@ -424,7 +424,7 @@ namespace ManagedCodeGen
                     string prefix = "";
                     if (!filename.Contains(config.CoreCLRRoot))
                     {
-                        prefix = Path.Combine(config.CoreCLRRoot, "src", config.SourceDirectory);
+                        prefix = Path.Combine(config.CoreCLRRoot, config.SourceDirectory);
                     }
 
                     if (File.Exists(Path.Combine(prefix, filename)))


### PR DESCRIPTION
I believe this to be the minimum change to facilitate removal of
the duplicated "src" folder level under "src/coreclr" in the
runtime repo. Before the removal we'll need to make a coordinated
runtime change to pass the source directory as "src/jit" instead
of just "jit"; the removal PR should subsequently change the
"src/jit" folder as the input argument to jit-format to just "jit".

Thanks

Tomas

Related to: https://github.com/dotnet/runtime/pull/44973

P.S. This is my first chance at a jitutils PR, thanks in advance for your
patience with me; I currently don't know how to test this without
merging in both this change and the envisioned runtime counterpart,
please let me know if you believe there's an easier way.