### PR TITLE
Fix regex that parses git diff

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -994,8 +994,8 @@ namespace ManagedCodeGen
                     return fileToTextDiffCount;
                 }
 
-                string fullBasePath = Path.GetFullPath(basePath);
-                string fullDiffPath = Path.GetFullPath(diffPath);
+                string fullBasePath = Path.GetFullPath(basePath).TrimEnd(Path.DirectorySeparatorChar);
+                string fullDiffPath = Path.GetFullPath(diffPath).TrimEnd(Path.DirectorySeparatorChar);
 
                 for (int i = 0; i < rawLines.Length; i += 3)
                 {

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -972,7 +972,7 @@ namespace ManagedCodeGen
             commandArgs.Add(diffPath);
             commandArgs.Add(basePath);
 
-            ProcessResult result = Utility.ExecuteProcess("git", commandArgs, true);
+            ProcessResult result = Utility.ExecuteProcess("git", commandArgs, true, basePath);
             Dictionary<string, int> fileToTextDiffCount = new Dictionary<string, int>();
 
             if (result.ExitCode != 0)

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -1011,6 +1011,11 @@ namespace ManagedCodeGen
                         };
 
                         string[] splitLine = gitMergedOutputRegex.Split(modifiedLine[2]);
+                        if (splitLine.Length != 6)
+                        {
+                            Console.WriteLine($"Couldn't parse output '{line}`.");
+                            continue;
+                        }
 
                         // Split will output:
                         //

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -62,7 +62,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("b|base", ref _basePath, "Base file or directory.");
                     syntax.DefineOption("d|diff", ref _diffPath, "Diff file or directory.");
                     syntax.DefineOption("r|recursive", ref _recursive, "Search directories recursively.");
-                    syntax.DefineOption("ext|fileExtension", ref _fileExtension, "File extension to look for.");
+                    syntax.DefineOption("ext|fileExtension", ref _fileExtension, "File extension to look for. By default, .dasm");
                     syntax.DefineOption("c|count", ref _count,
                         "Count of files and methods (at most) to output in the summary."
                       + " (count) improvements and (count) regressions of each will be included."
@@ -948,16 +948,17 @@ namespace ManagedCodeGen
         // There are files with diffs. Build up a dictionary mapping base file name to net text diff count.
         // Use "git diff" to do the analysis for us, then parse that output.
         //
-        // "git diff --no-index --exit-code --numstat" output shows added/deleted lines:
+        // "git diff --diff-filter=M --no-index --exit-code --numstat -z" output shows added/deleted lines:
         //
-        //   <added> <removed> <base-path> => <diff-path>
+        // With -diff-filter=M, "git diff" will only compare files modified files i.e. the ones that exists in both base and diff
+        // and ignore files that are present in one but not in other.
+        //
+        // With -z, the output uses field terminators of NULs (\0).
+        //   added\tremoved\t\0base-path-1\0diff-path-1\0added\tremoved\t....
         //
         // For example:
-        // 6       6       "dasmset_8/diff/Vector3Interop_ro/Vector3Interop_ro.dasm" => "dasmset_8/base/Vector3Interop_ro/Vector3Interop_ro.dasm"
+        // 6\t6\t\0d:\root\dasmset_8\base\Vector3Interop_ro.dasm\0d:\root\dasmset_8\diff\Vector3Interop_ro.dasm\0<next diff information>
         //
-        // Note, however, that it can also use a smaller output format, for example:
-        //
-        // 6       6       dasmset_8/{diff => base}/Vector3Interop_ro/Vector3Interop_ro.dasm
         public static Dictionary<string, int> DiffInText(string diffPath, string basePath)
         {
             // run get diff command to see if we have textual diffs.
@@ -965,117 +966,80 @@ namespace ManagedCodeGen
             List<string> commandArgs = new List<string>();
             commandArgs.Add("diff");
             commandArgs.Add("--no-index");
-            // only diff files that are present in both base and diff.
             commandArgs.Add("--diff-filter=M");
             commandArgs.Add("--exit-code");
             commandArgs.Add("--numstat");
-            commandArgs.Add(diffPath);
+            commandArgs.Add("-z");
             commandArgs.Add(basePath);
+            commandArgs.Add(diffPath);
 
+            Console.WriteLine($"git {string.Join(" ", commandArgs)}");
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
             ProcessResult result = Utility.ExecuteProcess("git", commandArgs, true);
-            Dictionary<string, int> fileToTextDiffCount = new Dictionary<string, int>();
+            stopwatch.Stop();
+            Console.WriteLine($"Took {stopwatch.Elapsed} to complete.");
+            Console.WriteLine();
+            Dictionary<string, int> fileToTextDiffCount = null;
 
             if (result.ExitCode != 0)
             {
                 // There are files with diffs. Build up a dictionary mapping base file name to net text diff count.
-                //
-                // diff --numstat output shows added/deleted lines
-                //   added removed base-path => diff-path
-                var rawLines = result.StdOut.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                fileToTextDiffCount = new Dictionary<string, int>();
+
+                var rawLines = result.StdOut.Split(new[] { "\0", Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                if (rawLines.Length % 3 != 0)
+                {
+                    Console.WriteLine($"Error parsing output: {result.StdOut}");
+                    return fileToTextDiffCount;
+                }
+
+                string fullBasePath = Path.GetFullPath(basePath);
                 string fullDiffPath = Path.GetFullPath(diffPath);
 
-                foreach (var line in rawLines)
+                for (int i = 0; i < rawLines.Length; i += 3)
                 {
-                    string manipulatedLine = line;
-                    string[] fields = null;
+                    string rawStats = rawLines[i];
+                    string rawBasePath = rawLines[i + 1];
+                    string rawDiffPath = rawLines[i + 2];
 
-                    int numFields = 5;
+                    string[] fields = rawStats.Split(new char[] { ' ', '\t', '"' }, StringSplitOptions.RemoveEmptyEntries);
 
-                    // Example output:
-                    // 32\t2\t/coreclr/bin/asm/asm/{diff => base}/101301.dasm
-                    //
-                    // This should be split into:
-                    //
-                    // 32\t2\t/coreclr/bin/asm/asm/base/101301.dasm\t/coreclr/bin/asm/asm/diff/101301.dasm
-                    Regex gitMergedOutputRegex = new Regex(@"\{((\w+(?:\/|\\)?)+)\s=>\s((\w+(?:\/|\\)?)+)\}");
-                    Regex whitespaceRegex = new Regex(@"(\w+)\s+(\w+)\s+(.*)");
-                    if (gitMergedOutputRegex.Matches(line).Count > 0)
+                    string parsedFullDiffFilePath = Path.GetFullPath(rawDiffPath);
+                    string parsedFullBaseFilePath = Path.GetFullPath(rawBasePath);
+
+                    string parsedDiffDir = Path.GetDirectoryName(parsedFullDiffFilePath);
+                    string parsedBaseDir = Path.GetDirectoryName(parsedFullBaseFilePath);
+
+
+                    if (!File.Exists(parsedFullBaseFilePath))
                     {
-                        // Do the first split to remove the integers from the file path.
-                        // Then reconstruct both the diff and the base paths.
-                        var groups = whitespaceRegex.Match(line).Groups;
-                        string[] modifiedLine = new string[] {
-                            groups[whitespaceRegex.GroupNameFromNumber(1)].ToString(),
-                            groups[whitespaceRegex.GroupNameFromNumber(2)].ToString(),
-                            groups[whitespaceRegex.GroupNameFromNumber(3)].ToString()
-                        };
-
-                        string[] splitLine = gitMergedOutputRegex.Split(modifiedLine[2]);
-                        if (splitLine.Length != 6)
-                        {
-                            Console.WriteLine($"Couldn't parse output '{line}`.");
-                            continue;
-                        }
-
-                        // Split will output:
-                        //
-                        // 32\t2\t/coreclr/bin/asm/asm/
-                        // {diffFolder}
-                        // {baseFolder}
-                        // 101301.dasm
-
-                        // Create the base path from the second group
-                        // {diff => base}
-                        string manipulatedBasePath = String.Join(Path.DirectorySeparatorChar, new string[] {
-                            splitLine[0],
-                            splitLine[3],
-                            splitLine[5]
-                        });
-
-                        // Create the diff path from the first 
-                        // {diff => base}
-                        string manipulatedDiffPath = String.Join(Path.DirectorySeparatorChar, new string[] {
-                            splitLine[0],
-                            splitLine[1],
-                            splitLine[5]
-                        });
-
-                        fields = new string[4] {
-                            modifiedLine[0],
-                            modifiedLine[1],
-                            manipulatedBasePath,
-                            manipulatedDiffPath
-                        };
-
-                        numFields = 4;
-                    }
-                    else
-                    {
-                        fields = line.Split(new char[] { ' ', '\t', '"' }, StringSplitOptions.RemoveEmptyEntries);
-                    }
-
-                    if (fields.Length != numFields)
-                    {
-                        Console.WriteLine($"Couldn't parse output '{line}`.");
+                        Console.WriteLine($"Error parsing path '{rawBasePath}'. `{parsedFullBaseFilePath}` doesn't exist.");
                         continue;
                     }
 
-                    // store diff-relative path
-                    string fullBaseFilePath = Path.GetFullPath(fields[2]);
-                    if (!File.Exists(fullBaseFilePath))
+                    if (parsedBaseDir != fullBasePath)
                     {
-                        Console.WriteLine($"Error parsing path '{line}'. `{fullBaseFilePath}` doesn't exist.");
+                        Console.WriteLine($"Error parsing path '{rawBasePath}'. `{parsedBaseDir}` and `{fullBasePath}` don't match.");
+                    }
+
+                    if (!File.Exists(parsedFullDiffFilePath))
+                    {
+                        Console.WriteLine($"Error parsing path '{rawDiffPath}'. `{parsedFullDiffFilePath}` doesn't exist.");
                         continue;
                     }
 
-                    string baseFilePath = fullBaseFilePath.Substring(fullDiffPath.Length + 1);
+                    if (parsedDiffDir != fullDiffPath)
+                    {
+                        Console.WriteLine($"Error parsing path '{rawDiffPath}'. `{parsedDiffDir}` and `{fullDiffPath}` don't match.");
+                    }
 
                     // Sometimes .dasm is parsed as binary and we don't get numbers, just dashes
                     int addCount = 0;
                     int delCount = 0;
                     Int32.TryParse(fields[0], out addCount);
                     Int32.TryParse(fields[1], out delCount);
-                    fileToTextDiffCount[baseFilePath] = addCount + delCount;
+                    fileToTextDiffCount[parsedFullBaseFilePath] = addCount + delCount;
                 }
 
                 Console.WriteLine($"Found {fileToTextDiffCount.Count()} files with textual diffs.");

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -972,7 +972,7 @@ namespace ManagedCodeGen
             commandArgs.Add(diffPath);
             commandArgs.Add(basePath);
 
-            ProcessResult result = Utility.ExecuteProcess("git", commandArgs, true, basePath);
+            ProcessResult result = Utility.ExecuteProcess("git", commandArgs, true);
             Dictionary<string, int> fileToTextDiffCount = new Dictionary<string, int>();
 
             if (result.ExitCode != 0)

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -997,7 +997,7 @@ namespace ManagedCodeGen
                     // This should be split into:
                     //
                     // 32\t2\t/coreclr/bin/asm/asm/base/101301.dasm\t/coreclr/bin/asm/asm/diff/101301.dasm
-                    Regex gitMergedOutputRegex = new Regex(@"\{(\w+)\s=>\s(\w+)\}");
+                    Regex gitMergedOutputRegex = new Regex(@"\{((\w+(?:\/|\\)?)+)\s=>\s((\w+(?:\/|\\)?)+)\}");
                     Regex whitespaceRegex = new Regex(@"(\w+)\s+(\w+)\s+(.*)");
                     if (gitMergedOutputRegex.Matches(line).Count > 0)
                     {
@@ -1021,16 +1021,18 @@ namespace ManagedCodeGen
 
                         // Create the base path from the second group
                         // {diff => base}
-                        string manipulatedBasePath = String.Join(splitLine[2], new string[] {
+                        string manipulatedBasePath = String.Join(Path.DirectorySeparatorChar, new string[] {
                             splitLine[0],
-                            splitLine[3]
+                            splitLine[3],
+                            splitLine[5]
                         });
 
                         // Create the diff path from the first 
                         // {diff => base}
-                        string manipulatedDiffPath = String.Join(splitLine[1], new string[] {
+                        string manipulatedDiffPath = String.Join(Path.DirectorySeparatorChar, new string[] {
                             splitLine[0],
-                            splitLine[3]
+                            splitLine[1],
+                            splitLine[5]
                         });
 
                         fields = new string[4] {
@@ -1057,7 +1059,7 @@ namespace ManagedCodeGen
                     string fullBaseFilePath = Path.GetFullPath(fields[2]);
                     if (!File.Exists(fullBaseFilePath))
                     {
-                        Console.WriteLine($"Couldn't parse output '{line}'.");
+                        Console.WriteLine($"Error parsing path '{line}'. `{fullBaseFilePath}` doesn't exist.");
                         continue;
                     }
 

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -950,7 +950,7 @@ namespace ManagedCodeGen
         //
         // "git diff --diff-filter=M --no-index --exit-code --numstat -z" output shows added/deleted lines:
         //
-        // With -diff-filter=M, "git diff" will only compare files modified files i.e. the ones that exists in both base and diff
+        // With -diff-filter=M, "git diff" will only compare modified files i.e. the ones that exists in both base and diff
         // and ignore files that are present in one but not in other.
         //
         // With -z, the output uses field terminators of NULs (\0).
@@ -973,13 +973,7 @@ namespace ManagedCodeGen
             commandArgs.Add(basePath);
             commandArgs.Add(diffPath);
 
-            Console.WriteLine($"git {string.Join(" ", commandArgs)}");
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
             ProcessResult result = Utility.ExecuteProcess("git", commandArgs, true);
-            stopwatch.Stop();
-            Console.WriteLine($"Took {stopwatch.Elapsed} to complete.");
-            Console.WriteLine();
             Dictionary<string, int> fileToTextDiffCount = null;
 
             if (result.ExitCode != 0)


### PR DESCRIPTION
We occasionally see warnings with `jit-analyze`:

```cmd
Couldn't parse output '182160   0       E:/lsra/binaries/EhWriteThru/bugfix/{dasmset_5/diff => dasmset_2/base}/System.Web.HttpUtility.log'.
Couldn't parse output '182160   0       E:/lsra/binaries/EhWriteThru/bugfix/{dasmset_5/diff => dasmset_2/base}/System.Web.log'.
```

They come depending on where `git diff` command was ran. I could see that the output of `git diff` was different depending on where `git diff` is ran, I am not sure why. Here is an example:

```cmd
D:\git\runtime>git diff --no-index --diff-filter=M --exit-code --numstat -- E:\lsra\binaries\EhWriteThru\bugfix\dasmset_5\tempd E:\lsra\binaries\EhWriteThru\bugfix\dasmset_2\tempb
34      51      "E:\\lsra\\binaries\\EhWriteThru\\bugfix\\dasmset_5\\tempd/CommandLine.dasm" => "E:\\lsra\\binaries\\EhWriteThru\\bugfix\\dasmset_2\\tempb/CommandLine.dasm"
182160  0       "E:\\lsra\\binaries\\EhWriteThru\\bugfix\\dasmset_5\\tempd/CommandLine.log" => "E:\\lsra\\binaries\\EhWriteThru\\bugfix\\dasmset_2\\tempb/CommandLine.log"

D:\git\runtime>cd D:\git\jitutils\src\jit-analyze\bin\Debug\net5.0

D:\git\jitutils\src\jit-analyze\bin\Debug\net5.0>git diff --no-index --diff-filter=M --exit-code --numstat -- E:\lsra\binaries\EhWriteThru\bugfix\dasmset_5\tempd E:\lsra\binaries\EhWriteThru\bugfix\dasmset_2\tempb
34      51      E:/lsra/binaries/EhWriteThru/bugfix/{dasmset_5/tempd => dasmset_2/tempb}/CommandLine.dasm
182160  0       E:/lsra/binaries/EhWriteThru/bugfix/{dasmset_5/tempd => dasmset_2/tempb}/CommandLine.log
```

In the second example, the file paths were condensed to use `=>` which fails our parsing logic. So I decided to pass workingDirectory for `git diff` command to be that of `basePath` and that prints complete path in the `git diff` output.

Edit: I have also updated the regex to fix the parsing error, so we should not see them anymore. So, with that we don't need to pass the `basePath` as working directory.