### PR TITLE
Optimize jit-analyze

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -57,7 +57,7 @@ namespace ManagedCodeGen
             private string _filter;
             private string _metric;
             private bool _showTextDiff = false;
-            private bool _sequential = true;
+            private bool _sequential = false;
 
             public Config(string[] args)
             {
@@ -527,11 +527,15 @@ namespace ManagedCodeGen
 
                 if (sequential)
                 {
-                    return Directory.EnumerateFiles(fullRootPath, searchPattern, searchOption)
-                             .Select(p => new FileInfo
+                    return Directory.EnumerateFiles(fullRootPath, searchPattern, searchOption).AsParallel()
+                             .Select(p =>
                              {
-                                 path = p.Substring(fullRootPath.Length).TrimStart(Path.DirectorySeparatorChar),
-                                 methodList = ExtractMethodInfo(p)
+                                 Console.WriteLine($"{Task.CurrentId}. {p}");
+                                 return new FileInfo
+                                 {
+                                     path = p.Substring(fullRootPath.Length).TrimStart(Path.DirectorySeparatorChar),
+                                     methodList = ExtractMethodInfo(p)
+                                 };
                              }).ToList();
                 }
                 else
@@ -541,6 +545,7 @@ namespace ManagedCodeGen
                         () => new List<FileInfo>(),
                         (p, loop, details) =>
                         {
+                            Console.WriteLine($"{Task.CurrentId}. {p}");
                             details.Add(new FileInfo
                             {
                                 path = p.Substring(fullRootPath.Length).TrimStart(Path.DirectorySeparatorChar),
@@ -1099,7 +1104,6 @@ namespace ManagedCodeGen
             // Parse incoming arguments
             Config config = new Config(args);
 
-         
             try
             {
                 Stopwatch stopwatch = new Stopwatch();

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -83,7 +83,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("filter", ref _filter,
                         "Only consider assembly files whose names match the filter");
                     syntax.DefineOption("skiptextdiff", ref _skipTextDiff,
-                        "Dump files that have textual diffs but no metric diffs.");
+                        "Skip analysis that checks for files that have textual diffs but no metric diffs.");
                 });
 
                 // Run validation code on parsed input to ensure we have a sensible scenario.

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -54,7 +54,7 @@ namespace ManagedCodeGen
             private string _note;
             private string _filter;
             private string _metric;
-            private bool _showTextDiff = false;
+            private bool _skipTextDiff = false;
 
             public Config(string[] args)
             {
@@ -82,7 +82,7 @@ namespace ManagedCodeGen
                         "Dump analysis data to specified file in tab-separated format.");
                     syntax.DefineOption("filter", ref _filter,
                         "Only consider assembly files whose names match the filter");
-                    syntax.DefineOption("textdiff", ref _showTextDiff,
+                    syntax.DefineOption("skiptextdiff", ref _skipTextDiff,
                         "Dump files that have textual diffs but no metric diffs.");
                 });
 
@@ -130,7 +130,7 @@ namespace ManagedCodeGen
             public string Filter {  get { return _filter; } }
 
             public string Metric {  get { return _metric; } }
-            public bool ShowTextDiff { get { return _showTextDiff;  } }
+            public bool SkipTextDiff { get { return _skipTextDiff;  } }
         }
 
         public class FileInfo
@@ -811,7 +811,7 @@ namespace ManagedCodeGen
             Console.WriteLine("\n{0} total methods with {1} differences ({2} improved, {3} regressed), {4} unchanged.",
                 sortedMethodCount, metricName, methodImprovementCount, methodRegressionCount, unchangedMethodCount);
 
-            if (config.ShowTextDiff)
+            if (!config.SkipTextDiff)
             {
                 // Show files with text diffs but no metric diffs.
 


### PR DESCRIPTION
While working on #305 , I realized that we do "git diff" only to check if there are any files that has textual diff and no metric diff. This was added to not do the analysis of metric diff if there are no real diffs in base/diff. However, common case is that there are diffs that users analyze using `jit-analyze`. It is very rare scenario where there would be no diffs. Additionally, the code that was added to perform "git diff" so we can skip the actual analysis was broken until now and was fixed recently in #305. So far, we always did the analysis of base/diff regardless of "git diff" told that there were diffs or not. So overall, I do not find doing "git diff" in the beginning much useful and it consumes 20~30 seconds to complete. More common cases (where there are diffs), we start the analysis of various metrics once "git diff" completes. So, I have moved the part of doing "textual diff" towards the end with an option of `-skiptextdiff` to skip if user thinks it is not required. That speeds up getting the interesting report from `jit-analyze` faster. 

Also, I have made the process that reads each file to extract metrics execute in parallel using `.AsParallel()` and that performs the analysis even faster than what it used to be before.