### PR TITLE
Counterpart fix for #44973 - remove extra "src" folder level

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -572,7 +572,7 @@ namespace ManagedCodeGen
                             // of the precompiled header file. It's not needed for clang-tidy and currently the precompiled
                             // header won't be found at the specified location: we run the build that generates compile_commands.json
                             // in ConfigureOnly mode so the precompiled headers are not generated.
-                            else if (option.Contains("src/jit") && !option.StartsWith("/Fp"))
+                            else if (option.Contains("jit") && !option.StartsWith("/Fp"))
                             {
                                 compileCommand = compileCommand + " " + option;
                             }
@@ -627,7 +627,7 @@ namespace ManagedCodeGen
 
             if (filename.EndsWith(".cpp"))
             {
-                List<string> commandArgs = new List<string> { tidyFix, "-checks=-*," + checks, fixErrors, "-header-filter=src/jit/.*", "-p=" + compileCommands, filename };
+                List<string> commandArgs = new List<string> { tidyFix, "-checks=-*," + checks, fixErrors, "-header-filter=jit/.*", "-p=" + compileCommands, filename };
 
                 if (verbose)
                 {

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -408,7 +408,7 @@ namespace ManagedCodeGen
             if (config.Filenames.Count() == 0)
             {
                 // add all files to a list of files
-                foreach (string filename in Directory.GetFiles(Path.Combine(config.CoreCLRRoot, "src", config.SourceDirectory)))
+                foreach (string filename in Directory.GetFiles(Path.Combine(config.CoreCLRRoot, config.SourceDirectory)))
                 {
                     // if it's not a directory, add it to our list
                     if (!Directory.Exists(filename) && (filename.EndsWith(".cpp") || filename.EndsWith(".h") || filename.EndsWith(".hpp")))
@@ -424,7 +424,7 @@ namespace ManagedCodeGen
                     string prefix = "";
                     if (!filename.Contains(config.CoreCLRRoot))
                     {
-                        prefix = Path.Combine(config.CoreCLRRoot, "src", config.SourceDirectory);
+                        prefix = Path.Combine(config.CoreCLRRoot, config.SourceDirectory);
                     }
 
                     if (File.Exists(Path.Combine(prefix, filename)))


### PR DESCRIPTION
As discussed about two weeks back in context of

https://github.com/dotnet/jitutils/pull/304

this change complements the runtime repo PR

https://github.com/dotnet/runtime/pull/44973

by fixing the correlated code in jitutils dealing with coreclr paths.

Thanks

Tomas