### PR TITLE
Remove MyGet references, add legacy feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,11 +3,8 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="dotnet-cli" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
-    <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
-    <add key="dotnet-core-myget" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet3.1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
Found in response to dotnet/core-eng#11839. dotnet.myget.org was recently shut down, and these references were missed. 

It appears most references weren't used at all (or packages retrieved from other feeds). The dotnet-corefxlab feed was providing system.commandline.0.1.0-e170320-1, which is now found on the myget-legacy feed. 

Tested locally by running build.cmd to completion.
