### PR TITLE
Add AllocSize and ExtraAllocBytes metric in jit-analyze

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -71,7 +71,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("w|warn", ref _warn,
                         "Generate warning output for files/methods that only "
                       + "exists in one dataset or the other (only in base or only in diff).");
-                    syntax.DefineOption("m|metric", ref _metric, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, DebugClauseCount, DebugVarCount");
+                    syntax.DefineOption("m|metric", ref _metric, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, AllocSize, DebugClauseCount, DebugVarCount");
                     syntax.DefineOption("note", ref _note,
                         "Descriptive note to add to summary output");
                     syntax.DefineOption("noreconcile", ref _noreconcile,
@@ -226,6 +226,16 @@ namespace ManagedCodeGen
             public override string ValueString => $"{Value}";
         }
 
+        public class AllocSizeMetric : Metric
+        {
+            public override string Name => "AllocSize";
+            public override string DisplayName => "Allocation Size";
+            public override string Unit => "byte";
+            public override bool LowerIsBetter => true;
+            public override Metric Clone() => new AllocSizeMetric();
+            public override string ValueString => $"{Value}";
+        }
+
         public class DebugClauseMetric : Metric
         {
             public override string Name => "DebugClauseCount";
@@ -253,7 +263,7 @@ namespace ManagedCodeGen
 
             static MetricCollection()
             {
-                s_metrics = new Metric[] { new CodeSizeMetric(), new PrologSizeMetric(), new PerfScoreMetric(), new InstrCountMetric(), new DebugClauseMetric(), new DebugVarMetric() };
+                s_metrics = new Metric[] { new CodeSizeMetric(), new PrologSizeMetric(), new PerfScoreMetric(), new InstrCountMetric(), new AllocSizeMetric(), new DebugClauseMetric(), new DebugVarMetric() };
                 s_metricNameToIndex = new Dictionary<string, int>(s_metrics.Length);
 
                 for (int i = 0; i < s_metrics.Length; i++)
@@ -541,6 +551,7 @@ namespace ManagedCodeGen
             // use new regex for perf score so we can still parse older files that did not have it.
             Regex perfScorePattern = new Regex(@"(PerfScore|perf score) (\d+(\.\d+)?)");
             Regex instrCountPattern = new Regex(@"instruction count ([0-9]{1,})");
+            Regex allocSizePattern = new Regex(@"allocated bytes for code ([0-9]{1,})");
             Regex debugInfoPattern = new Regex(@"Variable debug info: ([0-9]{1,}) live range\(s\), ([0-9]{1,}) var\(s\)");
 
             var result =
@@ -555,6 +566,7 @@ namespace ManagedCodeGen
                                  var codeAndPrologSizeMatch = codeAndPrologSizePattern.Match(x.line);
                                  var perfScoreMatch = perfScorePattern.Match(x.line);
                                  var instrCountMatch = instrCountPattern.Match(x.line);
+                                 var allocSizeMatch = allocSizePattern.Match(x.line);
                                  var debugInfoMatch = debugInfoPattern.Match(x.line);
                                  return new
                                  {
@@ -568,6 +580,8 @@ namespace ManagedCodeGen
                                         Double.Parse(perfScoreMatch.Groups[2].Value) : 0,
                                      instrCount = instrCountMatch.Success ?
                                         Int32.Parse(instrCountMatch.Groups[1].Value) : 0,
+                                     allocSize = allocSizeMatch.Success ?
+                                        Int32.Parse(allocSizeMatch.Groups[1].Value) : 0,
                                      debugClauseCount = debugInfoMatch.Success ?
                                         Int32.Parse(debugInfoMatch.Groups[1].Value) : 0,
                                      debugVarCount = debugInfoMatch.Success ?
@@ -594,6 +608,7 @@ namespace ManagedCodeGen
                                  mi.Metrics.Add("PrologSize", x.Sum(z => z.prologBytes));
                                  mi.Metrics.Add("PerfScore", x.Sum(z => z.perfScore));
                                  mi.Metrics.Add("InstrCount", x.Sum(z => z.instrCount));
+                                 mi.Metrics.Add("AllocSize", x.Sum(z => z.allocSize));
                                  mi.Metrics.Add("DebugClauseCount", x.Sum(z => z.debugClauseCount));
                                  mi.Metrics.Add("DebugVarCount", x.Sum(z => z.debugVarCount));
 

--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -239,8 +239,8 @@ namespace ManagedCodeGen
         public class ExtraAllocBytesMetric : Metric
         {
             public override string Name => "ExtraAllocBytes";
-            public override string DisplayName => "(Code Size - Allocation Size) bytes";
-            public override string Unit => "ratio";
+            public override string DisplayName => "Extra Allocation Size";
+            public override string Unit => "byte";
             public override bool LowerIsBetter => true;
             public override Metric Clone() => new ExtraAllocBytesMetric();
             public override string ValueString => $"{Value}";

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -175,7 +175,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("t|tag", ref _tag, "Name of root in output directory. Allows for many sets of output.");
                     syntax.DefineOption("c|corelib", ref _corelib, "Diff System.Private.CoreLib.dll.");
                     syntax.DefineOption("f|frameworks", ref _frameworks, "Diff frameworks.");
-                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, DebugClauseCount, DebugVarCount");
+                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, AllocSize, DebugClauseCount, DebugVarCount");
                     syntax.DefineOption("benchmarks", ref _benchmarks, "Diff core benchmarks.");
                     syntax.DefineOption("tests", ref _tests, "Diff all tests.");
                     syntax.DefineOption("gcinfo", ref _gcinfo, "Add GC info to the disasm output.");

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -175,7 +175,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("t|tag", ref _tag, "Name of root in output directory. Allows for many sets of output.");
                     syntax.DefineOption("c|corelib", ref _corelib, "Diff System.Private.CoreLib.dll.");
                     syntax.DefineOption("f|frameworks", ref _frameworks, "Diff frameworks.");
-                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, AllocSize, DebugClauseCount, DebugVarCount");
+                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, AllocSize, ExtraAllocBytes, DebugClauseCount, DebugVarCount");
                     syntax.DefineOption("benchmarks", ref _benchmarks, "Diff core benchmarks.");
                     syntax.DefineOption("tests", ref _tests, "Diff all tests.");
                     syntax.DefineOption("gcinfo", ref _gcinfo, "Add GC info to the disasm output.");


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/44370 , I added way to output the allocation size in the disasm. Use that to compare the allocation size. I have also added `ExtraAllocBytes` metric that will be used to diff (alloc size - code size) and in ideal cases it should be 0.