### PR TITLE
Enable jit-analyze to take multiple metrics as input and add an option to output .md file

### DIFF
--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -175,7 +175,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("t|tag", ref _tag, "Name of root in output directory. Allows for many sets of output.");
                     syntax.DefineOption("c|corelib", ref _corelib, "Diff System.Private.CoreLib.dll.");
                     syntax.DefineOption("f|frameworks", ref _frameworks, "Diff frameworks.");
-                    syntax.DefineOption("m|metric", ref _metric, false, "Metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, AllocSize, ExtraAllocBytes, DebugClauseCount, DebugVarCount");
+                    syntax.DefineOption("m|metrics", ref _metric, false, "Comma-separated metric to use for diff computations. Available metrics: CodeSize(default), PerfScore, PrologSize, InstrCount, AllocSize, ExtraAllocBytes, DebugClauseCount, DebugVarCount");
                     syntax.DefineOption("benchmarks", ref _benchmarks, "Diff core benchmarks.");
                     syntax.DefineOption("tests", ref _tests, "Diff all tests.");
                     syntax.DefineOption("gcinfo", ref _gcinfo, "Add GC info to the disasm output.");


### PR DESCRIPTION
I was tired of gathering the diff data for individual metric by invoking `jit-analyze` multiple times, so I went ahead and added ability to specify multiple metrics in comma-separated form so we can see the diffs of multiple metrics at one instead of invoking `jit-analyze` multiple times. Another motivation was that I wanted to output the diff result in `.md` file so I can just copy the contents from it and paste it on GH. So I went ahead and added an option of `--md` that will output the diff result (of all the metrics specified) in an `.md ` file.

Example of what you end up getting in `.md` can be seen in https://github.com/dotnet/runtime/pull/47307#issuecomment-765046091.

Contributes to https://github.com/dotnet/jitutils/issues/125