### PR TITLE
Fixing `GetBuildOS` for Windows to work with the latest dotnet/runtime builds

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -52,7 +52,7 @@ Sample config.json:
     "default": {
       "arch": "x64",
       "build": "Checked",
-      "os": "Windows_NT",
+      "os": "Windows",
       "coreclr": "C:\\michelm\\coreclr",
       "verbose": "true",
       "fix": "true"

--- a/doc/diffs.md
+++ b/doc/diffs.md
@@ -199,12 +199,12 @@ The "jit-diff diff" command has this help message:
     
     Examples:
     
-      jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root --base c:\coreclr_base\bin\Product
-    \Windows_NT.x64.Checked --diff c:\coreclr\bin\Product\Windows_NT.x86.Checked
+      jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\Windows.x64.Release\Tests\Core_Root --base c:\coreclr_base\bin\Product
+    \Windows.x64.Checked --diff c:\coreclr\bin\Product\Windows.x86.Checked
           Generate diffs of System.Private.CoreLib.dll by specifying baseline and
           diff compiler directories explicitly.
     
-      jit-diff diff --output c:\diffs --base c:\coreclr_base\bin\Product\Windows_NT.x64.Checked --diff
+      jit-diff diff --output c:\diffs --base c:\coreclr_base\bin\Product\Windows.x64.Checked --diff
           If run within the c:\coreclr git clone of dotnet/coreclr, does the same
           as the prevous example, using defaults.
     
@@ -267,7 +267,7 @@ The tool needs to know:
 These can all be specified explicitly. For example:
 
 ```
-    c:\coreclr> jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\Windows_NT.x64.release\Tests\Core_Root --base e:\coreclr2\bin\Product\Windows_NT.x64.checked --diff c:\coreclr\bin\Product\Windows_NT.x64.checked --crossgen c:\coreclr\bin\Product\Windows_NT.x64.release
+    c:\coreclr> jit-diff diff --output c:\diffs --corelib --core_root c:\coreclr\bin\tests\Windows.x64.release\Tests\Core_Root --base e:\coreclr2\bin\Product\Windows.x64.checked --diff c:\coreclr\bin\Product\Windows.x64.checked --crossgen c:\coreclr\bin\Product\Windows.x64.release
 ```
 
 Explanation:

--- a/doc/formatting.md
+++ b/doc/formatting.md
@@ -49,7 +49,7 @@ A common task for developers is to format their changes before submitting a GitH
 A developer can run the tool using the tests/scripts/format.py script in the coreclr repo:
 
 ```
-python tests\scripts\format.py --coreclr C:\gh\coreclr --arch x64 --os Windows_NT
+python tests\scripts\format.py --coreclr C:\gh\coreclr --arch x64 --os Windows
 ```
 
 This will run all build flavors and all projects for the user. This should be done on both
@@ -79,13 +79,13 @@ jit-format -a x64 -b Debug -o Windows -c C:\gh\coreclr -v lower.cpp codegenxarch
 Formatting jit directory.
 Formatting dll project.
 Building compile_commands.json.
-Using compile_commands.json found at C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json
+Using compile_commands.json found at C:\gh\coreclr\bin\obj\Windows.x64.Checked\compile_commands.json
 Running clang-tidy.
 Running:
-        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
+        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
 
 Running:
-        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
+        clang-tidy   -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
 
 Running: clang-format   C:\gh\coreclr\src\jit\codegenxarch.cpp
 Running: clang-format   C:\gh\coreclr\src\jit\lower.cpp
@@ -103,13 +103,13 @@ jit-format -a x64 -b Debug -o Windows -c C:\gh\coreclr -v --fix lower.cpp codege
 Formatting jit directory.
 Formatting dll project.
 Building compile_commands.json.
-Using compile_commands.json found at C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json
+Using compile_commands.json found at C:\gh\coreclr\bin\obj\Windows.x64.Checked\compile_commands.json
 Running clang-tidy.
 Running:
-        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
+        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\codegenxarch.cpp
 
 Running:
-        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows_NT.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
+        clang-tidy -fix  -checks=-*,readability-braces*,modernize-use-nullptr -header-filter=.* -p C:\gh\coreclr\bin\obj\Windows.x64.Checked\compile_commands.json C:\gh\coreclr\src\jit\lower.cpp
 
 Running: clang-format -i  C:\gh\coreclr\src\jit\codegenxarch.cpp
 Running: clang-format -i  C:\gh\coreclr\src\jit\lower.cpp

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,12 +1,12 @@
 {
     "asmdiff" : {
         "default": {
-            "base": "e:\\gh\\coreclr2\\bin\\Product\\Windows_NT.x86.checked",
-            "diff": "c:\\gh\\coreclr\\bin\\Product\\Windows_NT.x86.checked",
+            "base": "e:\\gh\\coreclr2\\bin\\Product\\Windows.x86.checked",
+            "diff": "c:\\gh\\coreclr\\bin\\Product\\Windows.x86.checked",
             "frameworks": "true",
             "output": "c:\\diffs",
-            "core_root": "c:\\gh\\coreclr\\bin\\tests\\Windows_NT.x86.checked\\Tests\\Core_Root",
-            "test_root": "c:\\gh\\coreclr\\bin\\tests\\Windows_NT.x86.Release"
+            "core_root": "c:\\gh\\coreclr\\bin\\tests\\Windows.x86.checked\\Tests\\Core_Root",
+            "test_root": "c:\\gh\\coreclr\\bin\\tests\\Windows.x86.Release"
         },
         "tools": [
             {
@@ -31,7 +31,7 @@
         "default": {
             "arch": "x64",
             "build": "Checked",
-            "os": "Windows_NT",
+            "os": "Windows",
             "coreclr": "C:\\gh\\coreclr",
             "verbose": "true",
             "fix": "true",

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -94,7 +94,7 @@ namespace ManagedCodeGen
             switch (platformMoniker)
             {
                 case "Windows":
-                    return "Windows_NT";
+                    return "Windows";
                 case "Linux":
                     return "Linux";
                 case "OSX":
@@ -407,9 +407,9 @@ namespace ManagedCodeGen
                     // --crossgen and --core_root need to be from the same build.
                     //
                     // E.g.:
-                    //    test_root: c:\gh\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release
-                    //    Core_Root: c:\gh\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root
-                    //    base/diff: c:\gh\runtime\artifacts\bin\coreclr\Windows_NT.x64.Checked
+                    //    test_root: c:\gh\runtime\artifacts\tests\coreclr\Windows.x64.Release
+                    //    Core_Root: c:\gh\runtime\artifacts\tests\coreclr\Windows.x64.Release\Tests\Core_Root
+                    //    base/diff: c:\gh\runtime\artifacts\bin\coreclr\Windows.x64.Checked
 
                     List<string> archList;
                     List<string> buildList;
@@ -759,11 +759,11 @@ namespace ManagedCodeGen
                     string[] diffExampleText = {
                     @"Examples:",
                     @"",
-                    @"  jit-diff diff --output c:\diffs --corelib --core_root c:\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root --base c:\runtime_base\artifacts\bin\coreclr\Windows_NT.x64.Checked --diff c:\runtime\artifacts\bin\coreclr\Windows_NT.x86.Checked",
+                    @"  jit-diff diff --output c:\diffs --corelib --core_root c:\runtime\artifacts\tests\coreclr\Windows.x64.Release\Tests\Core_Root --base c:\runtime_base\artifacts\bin\coreclr\Windows.x64.Checked --diff c:\runtime\artifacts\bin\coreclr\Windows.x86.Checked",
                     @"      Generate diffs of prejitted code for System.Private.CoreLib.dll by specifying baseline and",
                     @"      diff compiler directories explicitly.",
                     @"",
-                    @"  jit-diff diff --output c:\diffs --base c:\runtime_base\artifacts\bin\coreclr\Windows_NT.x64.Checked --diff",
+                    @"  jit-diff diff --output c:\diffs --base c:\runtime_base\artifacts\bin\coreclr\Windows.x64.Checked --diff",
                     @"      If run within the c:\runtime git clone of dotnet/runtime, does the same",
                     @"      as the prevous example, using defaults.",
                     @"",


### PR DESCRIPTION
This was changed to just `Windows` back in November: https://github.com/dotnet/runtime/pull/43651