### PR TITLE
Fix "error: invalid option --metric" error

### DIFF
--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -352,7 +352,7 @@ namespace ManagedCodeGen
                     analysisArgs.Add("--count");
                     analysisArgs.Add(config.Count.ToString());
                     analysisArgs.Add("--recursive");
-                    analysisArgs.Add("--metric");
+                    analysisArgs.Add("--metrics");
                     analysisArgs.Add(config.Metric);
                     analysisArgs.Add("--note");
 


### PR DESCRIPTION
`jit-diff diff` executes `jit-analyze` after running the diffs and always fail with `error: invalid option --metric`
I guess it was introduced in https://github.com/dotnet/jitutils/pull/312
