### PR TITLE
Add Nullable<int> to pmi

### DIFF
--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -1050,7 +1050,7 @@ class Worker
         }
 
         // Types we will use for instantiation attempts.
-        Type[] typesToTry = new Type[] { typeof(object), typeof(byte), typeof(short), typeof(int), typeof(double), typeof(Vector<float>), typeof(long) };
+        Type[] typesToTry = new Type[] { typeof(object), typeof(byte), typeof(short), typeof(int), typeof(double), typeof(Vector<float>), typeof(long), typeof(int?) };
 
         // To keep things sane, we won't try and instantiate too many copies
         int instantiationLimit = genericArguments.Length * typesToTry.Length;
@@ -1142,7 +1142,7 @@ class Worker
         }
 
         // Types we will use for instantiation attempts.
-        Type[] typesToTry = new Type[] { typeof(object), typeof(byte), typeof(short), typeof(int), typeof(double), typeof(Vector<float>), typeof(long) };
+        Type[] typesToTry = new Type[] { typeof(object), typeof(byte), typeof(short), typeof(int), typeof(double), typeof(Vector<float>), typeof(long), typeof(int?) };
 
         // To keep things sane, we won't try and instantiate too many copies
         int instantiationLimit = genericArguments.Length * typesToTry.Length;


### PR DESCRIPTION
Makes `--pmi` 7% slower.

@AndyAyersMS did you mean to file a PR like this in https://github.com/dotnet/runtime/pull/48161#issuecomment-777627105 or just to test locally?