### PR TITLE
Delete "Error parsing path " messages when comparing benchmarks

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -1055,9 +1055,6 @@ namespace ManagedCodeGen
                     return fileToTextDiffCount;
                 }
 
-                string fullBasePath = Path.GetFullPath(basePath).TrimEnd(Path.DirectorySeparatorChar);
-                string fullDiffPath = Path.GetFullPath(diffPath).TrimEnd(Path.DirectorySeparatorChar);
-
                 for (int i = 0; i < rawLines.Length; i += 3)
                 {
                     string rawStats = rawLines[i];
@@ -1069,30 +1066,17 @@ namespace ManagedCodeGen
                     string parsedFullDiffFilePath = Path.GetFullPath(rawDiffPath);
                     string parsedFullBaseFilePath = Path.GetFullPath(rawBasePath);
 
-                    string parsedDiffDir = Path.GetDirectoryName(parsedFullDiffFilePath);
-                    string parsedBaseDir = Path.GetDirectoryName(parsedFullBaseFilePath);
-
-
                     if (!File.Exists(parsedFullBaseFilePath))
                     {
                         Console.WriteLine($"Error parsing path '{rawBasePath}'. `{parsedFullBaseFilePath}` doesn't exist.");
                         continue;
                     }
 
-                    if (parsedBaseDir != fullBasePath)
-                    {
-                        Console.WriteLine($"Error parsing path '{rawBasePath}'. `{parsedBaseDir}` and `{fullBasePath}` don't match.");
-                    }
 
                     if (!File.Exists(parsedFullDiffFilePath))
                     {
                         Console.WriteLine($"Error parsing path '{rawDiffPath}'. `{parsedFullDiffFilePath}` doesn't exist.");
                         continue;
-                    }
-
-                    if (parsedDiffDir != fullDiffPath)
-                    {
-                        Console.WriteLine($"Error parsing path '{rawDiffPath}'. `{parsedDiffDir}` and `{fullDiffPath}` don't match.");
                     }
 
                     // Sometimes .dasm is parsed as binary and we don't get numbers, just dashes


### PR DESCRIPTION
Benchmarks are living dasm in subfolders, like: `dasmset_153\base\Roslyn\CscBench`, but `parsedDiffDir` was not expecting it so it was producing a bunch of errors like:
```
Error parsing path 'D:/Sergey/diffs/dasmset_159/base/BenchmarksGame/k-nucleotide/k-nucleotide-1/k-nucleotide-1.dasm'. `D:\Sergey\diffs\dasmset_159\base\BenchmarksGame\k-nucleotide\k-nucleotide-1` and `D:\Sergey\diffs\dasmset_159\base` don't match.
Error parsing path 'D:/Sergey/diffs/dasmset_159/diff/BenchmarksGame/k-nucleotide/k-nucleotide-1/k-nucleotide-1.dasm'. `D:\Sergey\diffs\dasmset_159\diff\BenchmarksGame\k-nucleotide\k-nucleotide-1` and `D:\Sergey\diffs\dasmset_159\diff` don't match.
Error parsing path 'D:/Sergey/diffs/dasmset_159/base/BenchmarksGame/pidigits/pidigits-3/pidigits-3.dasm'. `D:\Sergey\diffs\dasmset_159\base\BenchmarksGame\pidigits\pidigits-3` and `D:\Sergey\diffs\dasmset_159\base` don't match.
***
```
because we did not have an actual dependency on `parsedBaseDir` to be equal to `fullBasePath` we can just delete these checks.

PTAL @dotnet/jit-contrib 