### PR TITLE
Skip printing headers if count==0

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -769,8 +769,13 @@ namespace ManagedCodeGen
                 }
             }
 
-            // Todo: handle higher is better metrics
             int requestedCount = config.Count;
+            if (requestedCount == 0)
+            {
+                return (Math.Abs(totalDeltaMetric.Value) == 0 ? 0 : -1, summaryContents.ToString());
+            }
+
+            // Todo: handle higher is better metrics
             var sortedFileImprovements = fileDeltaList
                                             .Where(x => x.deltaMetrics.GetMetric(metricName).Value < 0)
                                             .OrderBy(d => d.deltaMetrics.GetMetric(metricName).Value).ToList();


### PR DESCRIPTION
Minor PR to not show headers if `-c 0` passed to `jit-analyze`. I am trying to get just the overall % diffs and not interested in individual file diffs.