### PR TITLE
Add FindRedundantTest() in AnalyzeAsm

### DIFF
--- a/src/AnalyzeAsm/Program.cs
+++ b/src/AnalyzeAsm/Program.cs
@@ -1925,7 +1925,8 @@ namespace AnalyzeAsm
         }
 
         /// <summary>
-        /// Summarizes "ldr wzr
+        /// Find redundant test instructions that can be deleted because the previous instruction already
+        /// wrote to EFLAGS and the next instruction can read that flag.
         /// </summary>
         static StringBuilder FindRedundantTest(string inputFile, ref int totalMethods, ref int foundMethods, ref int totalTestGroups)
         {

--- a/src/AnalyzeAsm/Program.cs
+++ b/src/AnalyzeAsm/Program.cs
@@ -114,7 +114,7 @@ namespace AnalyzeAsm
             }
             result.AppendLine($"Processed {totalMethods} methods. Found {foundMethods} methods containing {totalTestGroups} groups.");
 
-            WriteResults(@"E:\perfinvestigation\52297\binaries\dasm\dasmset_1\jb.txt", result.ToString());
+            WriteResults(@"E:\perfinvestigation\52297\binaries\dasm\dasmset_1\je_jne_lea.txt", result.ToString());
             
 
             watch.Stop();
@@ -1939,17 +1939,17 @@ namespace AnalyzeAsm
              */
             var testRegex = new Regex(@"test     (\w+), (\w+)");
 
-            //var aluRegex = new Regex(@"(add|and|dec|inc|lsl|neg|or|sal|sar|shl|shr|sbb|sub|xor)      (\w+),?");
-            //List<string> ops = new List<string>()
-            //{
-            //    " je ", " jne ", " jz ", "jnz "
-            //};
-
-            var aluRegex = new Regex(@"(add|btr|btc|bts|imul|mul|rol|ror|sal|sar|shl|shr|sbb|sub|xor)      (\w+),?");
+            var aluRegex = new Regex(@"(add|and|dec|inc|lsl|lea|neg|or|sal|sar|shl|shr|sbb|sub|xor)      (\w+),?");
             List<string> ops = new List<string>()
             {
-                " jb ", " jnb ", " jae ", "jnae "
+                " je ", " jne ", " jz ", "jnz "
             };
+
+            //var aluRegex = new Regex(@"(add|btr|btc|bts|imul|mul|rol|ror|sal|sar|shl|shr|sbb|sub|xor)      (\w+),?");
+            //List<string> ops = new List<string>()
+            //{
+            //    " jb ", " jnb ", " jae ", "jnae "
+            //};
 
             bool foundRedundantTest = false;
             string header = "";


### PR DESCRIPTION
Added `FindRedundantTest()` method that looks for redundant `test` instruction in the dasm files. I have scoped it to limited jump instructions, but can be extended in the future. Used in https://github.com/dotnet/runtime/issues/53053.