### PR TITLE
Add sorting by name to "Top method regressions/improvements"

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -943,10 +943,14 @@ namespace ManagedCodeGen
                                         }).ToList();
             var sortedMethodImprovements = methodDeltaList
                                             .Where(x => x.deltaMetric.Value< 0)
-                                            .OrderBy(d => d.deltaMetric.Value).ToList();
+                                            .OrderBy(d => d.deltaMetric.Value)
+                                            .ThenBy(d => d.name)
+                                            .ToList();
             var sortedMethodRegressions = methodDeltaList
                                             .Where(x => x.deltaMetric.Value > 0)
-                                            .OrderByDescending(d => d.deltaMetric.Value).ToList();
+                                            .OrderByDescending(d => d.deltaMetric.Value)
+                                            .ThenBy(d => d.name)
+                                            .ToList();
             int methodImprovementCount = sortedMethodImprovements.Count();
             int methodRegressionCount = sortedMethodRegressions.Count();
             int sortedMethodCount = methodImprovementCount + methodRegressionCount;
@@ -954,10 +958,14 @@ namespace ManagedCodeGen
 
             var sortedMethodImprovementsByPercentage = methodDeltaList
                                             .Where(x => x.deltaMetric.Value < 0)
-                                            .OrderBy(d => d.deltaMetric.Value / d.baseMetric.Value).ToList();
+                                            .OrderBy(d => d.deltaMetric.Value / d.baseMetric.Value)
+                                            .ThenBy(d => d.name)
+                                            .ToList();
             var sortedMethodRegressionsByPercentage = methodDeltaList
                                             .Where(x => x.deltaMetric.Value > 0)
-                                            .OrderByDescending(d => d.deltaMetric.Value / d.baseMetric.Value).ToList();
+                                            .OrderByDescending(d => d.deltaMetric.Value / d.baseMetric.Value)
+                                            .ThenBy(d => d.name)
+                                            .ToList();
 
             void DisplayMethodMetric(string headerText, string subtext, int methodCount, dynamic list)
             {


### PR DESCRIPTION
I am using meld to compare different jit-analyze outputs and sometimes I see diffs like:
```diff
-           4 (10.00% of base) : 116814.dasm - System.Data.SqlTypes.SqlDecimal:ToSqlSingle():System.Data.SqlTypes.SqlSingle:this
-           4 (10.00% of base) : 116807.dasm - System.Data.SqlTypes.SqlDecimal:ToSqlBoolean():System.Data.SqlTypes.SqlBoolean:this
           4 (10.00% of base) : 116811.dasm - System.Data.SqlTypes.SqlDecimal:ToSqlInt32():System.Data.SqlTypes.SqlInt32:this
+           4 (10.00% of base) : 116807.dasm - System.Data.SqlTypes.SqlDecimal:ToSqlBoolean():System.Data.SqlTypes.SqlBoolean:this
+           4 (10.00% of base) : 116814.dasm - System.Data.SqlTypes.SqlDecimal:ToSqlSingle():System.Data.SqlTypes.SqlSingle:this

```
that I would like to avoid.



PTAL @dotnet/jit-contrib 