### PR TITLE
Disable parallelism for crossgen2

### DIFF
--- a/src/jit-dasm/jit-dasm.cs
+++ b/src/jit-dasm/jit-dasm.cs
@@ -710,6 +710,7 @@ namespace ManagedCodeGen
 
             override protected ProcessResult ExecuteProcess(List<string> commandArgs, bool capture)
             {
+                commandArgs.Add("--parallelism 1");
                 foreach (var envVar in _environmentVariables)
                 {
                     commandArgs.Add("--codegenopt");


### PR DESCRIPTION
with parallelism on, crossgen outputs some abracadabra for JitDisasm (methods overlap)