### PR TITLE
Recognize curl as a downloading tool

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -83,7 +83,7 @@ function download_tools {
         echo "Downloading clang-format to bin directory"
         # download appropriate version of clang-format
         if (( _machineHasCurl == 1 )); then
-            curl --retry 4 --progress-bar --fail "$clangFormatUrl" -o bin/clang-format
+            curl --retry 4 --progress-bar --location --fail "$clangFormatUrl" -o bin/clang-format
         else
             wget --tries 4 --progress=dot:giga "$clangFormatUrl" -O bin/clang-format
         fi
@@ -98,7 +98,7 @@ function download_tools {
         echo "Downloading clang-tidy to bin directory"
         # download appropriate version of clang-tidy
         if (( _machineHasCurl == 1 )); then
-            curl --retry 4 --progress-bar --fail "$clangTidyUrl" -o bin/clang-tidy
+            curl --retry 4 --progress-bar --location --fail "$clangTidyUrl" -o bin/clang-tidy
         else
             wget --tries 4 --progress=dot:giga "$clangTidyUrl" -O bin/clang-tidy
         fi


### PR DESCRIPTION
Chances of having curl on a fresh Linux / macOS install are actually higher than having wget, but even if there is a tie, using available tool in PATH which does the job right is good. This is the only script related to runtime that force the user to install wget.

.. was about to run `brew install wget` then thought I should do this first. 😄
