### PR TITLE
use retry for downloading clang tools

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -75,7 +75,7 @@ function download_tools {
     if validate_url ${clangFormatUrl} > /dev/null; then
         echo "Downloading clang-format to bin directory"
         # download appropriate version of clang-format
-        wget --progress=dot:giga ${clangFormatUrl} -O bin/clang-format
+        wget --tries 4 --progress=dot:giga ${clangFormatUrl} -O bin/clang-format
         chmod 751 bin/clang-format
     else
         echo "clang-format not found here: ${clangFormatUrl}"
@@ -86,7 +86,7 @@ function download_tools {
     if validate_url ${clangTidyUrl} > /dev/null; then
         echo "Downloading clang-tidy to bin directory"
         # download appropriate version of clang-tidy
-        wget --progress=dot:giga ${clangTidyUrl} -O bin/clang-tidy
+        wget --tries 4 --progress=dot:giga ${clangTidyUrl} -O bin/clang-tidy
         chmod 751 bin/clang-tidy
     else
         echo "clang-tidy not found here: ${clangTidyUrl}"


### PR DESCRIPTION
Add retry logic during downloading clang tools in unix. Turns out we only added retry logic for windows in https://github.com/dotnet/jitutils/pull/327/files and not for linux.