### PR TITLE
Use non-deprecated Azure Pipelines Ubuntu/Windows pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,13 +9,13 @@ jobs:
   parameters:
     agentOs: Windows_NT
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
 
 - template: /eng/build.yml
   parameters:
     agentOs: Linux
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-20.04
 
 - template: /eng/build.yml
   parameters:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -77,6 +77,16 @@ function download_tools {
     info=$(dotnet --info |grep RID:)
     info=${info##*RID:* }
 
+    # override common RIDs with compatible version so we don't need to upload binaries for each RID
+    case $info in
+        osx.*-x64)
+        info=osx.10.15-x64
+        ;;
+        ubuntu.*-x64)
+        info=ubuntu.18.04-x64
+        ;;
+    esac
+
     clangFormatUrl=https://clrjit.blob.core.windows.net/clang-tools/${info}/clang-format
 
     if validate_url "$clangFormatUrl" > /dev/null; then


### PR DESCRIPTION
ubuntu-16.04 was removed recently (https://github.com/actions/virtual-environments/issues/3287), bumping to 20.04

win2016 will be removed in March: https://github.com/actions/virtual-environments/issues/4312, bumping to windows-2019