### PR TITLE
Build coredistools for macOS arm64

### DIFF
--- a/build-coredistools.sh
+++ b/build-coredistools.sh
@@ -6,6 +6,7 @@ CrossRootfsDirectory=$2
 case "$TargetOSArchitecture" in
     linux-arm)
         CrossCompiling=1
+        BuildUsesCrossRootfs=1
         LLVMDefaultTargetTriple=thumbv7-linux-gnueabihf
         LLVMHostTriple=arm-linux-gnueabihf
         LLVMTargetsToBuild="AArch64;ARM"
@@ -13,6 +14,7 @@ case "$TargetOSArchitecture" in
 
     linux-arm64)
         CrossCompiling=1
+        BuildUsesCrossRootfs=1
         LLVMDefaultTargetTriple=aarch64-linux-gnu
         LLVMHostTriple=aarch64-linux-gnu
         LLVMTargetsToBuild="AArch64;ARM"
@@ -20,6 +22,15 @@ case "$TargetOSArchitecture" in
 
     linux-x64|osx-x64)
         CrossCompiling=0
+        BuildUsesCrossRootfs=0
+        LLVMTargetsToBuild="AArch64;ARM;X86"
+        ;;
+
+    osx-arm64)
+        CrossCompiling=1
+        BuildUsesCrossRootfs=0
+        LLVMDefaultTargetTriple=aarch64-apple-darwin
+        LLVMHostTriple=aarch64-apple-darwin
         LLVMTargetsToBuild="AArch64;ARM;X86"
         ;;
 
@@ -28,7 +39,7 @@ case "$TargetOSArchitecture" in
         exit 1
 esac
 
-if [[ $CrossCompiling -eq 1 && ! -d $CrossRootfsDirectory ]]; then
+if [[ $BuildUsesCrossRootfs -eq 1 && ! -d $CrossRootfsDirectory ]]; then
     echo "Invalid or unspecified CrossRootfsDirectory: $CrossRootfsDirectory"
     exit 1
 fi

--- a/coredistools.yml
+++ b/coredistools.yml
@@ -27,9 +27,9 @@ trigger:
 resources:
   containers:
   - container: ubuntu-16.04-arm
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-20200413125008-09ec757
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-20210719121212-8a8d3be
   - container: ubuntu-16.04-arm64
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20200413125008-cfdd435
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
 
 variables:
   LLVMRepositoryUri: https://github.com/llvm/llvm-project.git
@@ -103,7 +103,7 @@ jobs:
   displayName: Build coredistools Linux x64
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
 
   variables:
     TargetOSArchitecture: linux-x64
@@ -135,6 +135,34 @@ jobs:
 
   variables:
     TargetOSArchitecture: osx-x64
+
+  workspace:
+    clean: all
+
+  steps:
+  - template: /eng/download-checkout-llvm.yml
+
+  - template: /eng/download-llvm-release.yml
+    parameters:
+      os: macos
+      release: $(LLVMSourceVersion)
+
+  - script: ./build-coredistools.sh $(TargetOSArchitecture)
+    displayName: Build coredistools
+
+  - publish: $(Build.SourcesDirectory)/artifacts/$(TargetOSArchitecture)/bin/libcoredistools.dylib
+    artifact: coredistools-$(TargetOSArchitecture)
+    displayName: Publish coredistools
+
+- job: crossbuild_coredistools_macos_arm64
+  dependsOn: checkout_llvm
+  displayName: Build coredistools macOS arm64
+
+  pool:
+    vmImage: macOS-11
+
+  variables:
+    TargetOSArchitecture: osx-arm64
 
   workspace:
     clean: all


### PR DESCRIPTION
I am sure that this is going to fail building for macOS arm64 and thus requiring us to update and use a newer version of LLVM.
Let's test anyway...