### PR TITLE
Update coredistools infrastructure dependencies

### DIFF
--- a/coredistools.yml
+++ b/coredistools.yml
@@ -9,6 +9,7 @@ pr:
     - build-coredistools.cmd
     - build-coredistools.sh
     - build-tblgen.cmd
+    - coredistools.yml
     - pack-coredistools.cmd
 
 trigger:
@@ -22,6 +23,7 @@ trigger:
     - build-coredistools.cmd
     - build-coredistools.sh
     - build-tblgen.cmd
+    - coredistools.yml
     - pack-coredistools.cmd
 
 resources:

--- a/coredistools.yml
+++ b/coredistools.yml
@@ -27,9 +27,9 @@ trigger:
 resources:
   containers:
   - container: ubuntu-16.04-arm
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-20200413125008-09ec757
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-20210719121212-8a8d3be
   - container: ubuntu-16.04-arm64
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20200413125008-cfdd435
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
 
 variables:
   LLVMRepositoryUri: https://github.com/llvm/llvm-project.git
@@ -103,7 +103,7 @@ jobs:
   displayName: Build coredistools Linux x64
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
 
   variables:
     TargetOSArchitecture: linux-x64

--- a/src/coredistools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
+++ b/src/coredistools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
@@ -6,7 +6,7 @@
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <license type="file">LICENSE.txt</license>
+    <license type="file">LICENSE.TXT</license>
     <projectUrl>https://github.com/dotnet/jitutils</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Disassembly Tools for dotnet/runtime</description>


### PR DESCRIPTION
Update the Linux jobs to use ubuntu-18.04 pool and also update the Docker containers to use the latest images.