### PR TITLE
Add option of retainOnlyTopFiles to jit-analyze

### DIFF
--- a/src/jit-analyze/jit-analyze.cs
+++ b/src/jit-analyze/jit-analyze.cs
@@ -113,7 +113,7 @@ namespace ManagedCodeGen
                     syntax.DefineOption("skiptextdiff", ref _skipTextDiff,
                         "Skip analysis that checks for files that have textual diffs but no metric diffs.");
                     syntax.DefineOption("retainOnlyTopFiles ", ref _retainOnlyTopFiles,
-                        "Retain only the .dasm files that has top 'count' improvements/regressions. Delete other files. Useful in CI scenario to reduce the upload size.");
+                        "Retain only the top 'count' improvements/regressions .dasm files. Delete other files. Useful in CI scenario to reduce the upload size.");
                     syntax.DefineOption("override-total-base-metric", ref _overrideTotalBaseMetric, ParseDouble,
                         "Override the total base metric shown in the output with this value. Useful when only changed .dasm files are present and these values are known.");
                     syntax.DefineOption("override-total-diff-metric", ref _overrideTotalDiffMetric, ParseDouble,


### PR DESCRIPTION
`RetainBigDiffFilesOnly` will make `jit-analyze` to delete the `.dasm` files and retain just the top `count` files that contains largest diffs. This will help us in reducing the `.dasm` files size when we upload them as part of CI. By default, this option is off and hence we will never delete those files.

Thoughts?