### PR TITLE
Update LLVM version to 13.0.1

### DIFF
--- a/build-coredistools.cmd
+++ b/build-coredistools.cmd
@@ -53,7 +53,7 @@ if not exist "%BinariesDirectory%" (
 pushd "%BinariesDirectory%"
 
 cmake.exe ^
-    -G "Visual Studio 16 2019" ^
+    -G "Visual Studio 17 2022" ^
     -A %GeneratorPlatform% ^
     -DCMAKE_INSTALL_PREFIX="%StagingDirectory%" ^
     -DLLVM_DEFAULT_TARGET_TRIPLE=%LLVMDefaultTargetTriple% ^

--- a/build-tblgen.cmd
+++ b/build-tblgen.cmd
@@ -20,7 +20,7 @@ if not exist "%BinariesDirectory%" (
 pushd "%BinariesDirectory%"
 
 cmake.exe ^
-    -G "Visual Studio 16 2019" ^
+    -G "Visual Studio 17 2022" ^
     -DCMAKE_INSTALL_PREFIX="%RootDirectory%\" ^
     -DLLVM_TARGETS_TO_BUILD=AArch64;ARM;X86 ^
     "%SourcesDirectory%\llvm-project\llvm"

--- a/coredistools.yml
+++ b/coredistools.yml
@@ -36,7 +36,7 @@ resources:
 variables:
   LLVMRepositoryUri: https://github.com/llvm/llvm-project.git
   LLVMSourceBundle: llvm-project.bundle
-  LLVMSourceVersion: llvmorg-13.0.0
+  LLVMSourceVersion: llvmorg-13.0.1
 
 jobs:
 - job: checkout_llvm

--- a/coredistools.yml
+++ b/coredistools.yml
@@ -28,10 +28,10 @@ trigger:
 
 resources:
   containers:
-  - container: ubuntu-16.04-arm
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-20210719121212-8a8d3be
-  - container: ubuntu-16.04-arm64
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20210719121212-8a8d3be
+  - container: ubuntu-18.04-arm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-20220312201346-b9de666
+  - container: ubuntu-18.04-arm64
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-20220312201346-b2c2436
 
 variables:
   LLVMRepositoryUri: https://github.com/llvm/llvm-project.git
@@ -73,12 +73,12 @@ jobs:
   strategy:
     matrix:
       arm:
-        ContainerImage: ubuntu-16.04-arm
+        ContainerImage: ubuntu-18.04-arm
         CrossRootfsDirectory: /crossrootfs/arm
         TargetOSArchitecture: linux-arm
 
       arm64:
-        ContainerImage: ubuntu-16.04-arm64
+        ContainerImage: ubuntu-18.04-arm64
         CrossRootfsDirectory: /crossrootfs/arm64
         TargetOSArchitecture: linux-arm64
 

--- a/eng/download-llvm-release.py
+++ b/eng/download-llvm-release.py
@@ -12,9 +12,9 @@ from urllib import request
 from urllib.error import URLError, HTTPError
 
 Release_urls = {
-  'llvmorg-13.0.0': {
-      'linux': 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz',
-      'macos': 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz'
+  'llvmorg-13.0.1': {
+      'linux': 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz',
+      'macos': 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz'
   }
 }
 


### PR DESCRIPTION
* Use LLVM 13.0.1
* Use Visual Studio 2022 for building on Windows
* Use Ubuntu 18.04 containers for building on Linux

Work towards https://github.com/dotnet/jitutils/issues/349