### PR TITLE
Readd myget-legacy feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,6 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,8 +3,10 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
+
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
   </packageSources>
   <packageRestore>
     <add key="enabled" value="False" />


### PR DESCRIPTION
We are still depending on an ancient version of System.Commandline, 0.1.0-e170320-1, which we get from this feed. Readd it to unblock things, otherwise all our SPMI jobs fail in dotnet/runtime when they try to build jitutils.