### PR TITLE
Allow jitutils SDK versions to roll forward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.400",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
Hopefully this should avoid some issues in the future related to upgrading .NET SDKs