### PR TITLE
Print the clang tools download url

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -144,10 +144,11 @@ echo Tools can be found at http://llvm.org/releases/download.html#3.8.0
 
 :: Download clang-format and clang-tidy
 echo Downloading formatting tools
-
+echo Downloading clang-format from "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-format.exe"
 call :download_url clang-format "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-format.exe" bin\clang-format.exe
 if %__ExitCode% NEQ 0 goto :eof
 
+echo Downloading clang-tidy from "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-tidy.exe"
 call :download_url clang-tidy "https://clrjit.blob.core.windows.net/clang-tools/windows/clang-tidy.exe" bin\clang-tidy.exe
 if %__ExitCode% NEQ 0 goto :eof
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -90,7 +90,7 @@ function download_tools {
     clangFormatUrl=https://clrjit.blob.core.windows.net/clang-tools/${info}/clang-format
 
     if validate_url "$clangFormatUrl" > /dev/null; then
-        echo "Downloading clang-format to bin directory"
+        echo "Downloading clang-format to bin directory from: $clangFormatUrl"
         # download appropriate version of clang-format
         if (( _machineHasCurl == 1 )); then
             curl --retry 4 --progress-bar --location --fail "$clangFormatUrl" -o bin/clang-format
@@ -105,7 +105,7 @@ function download_tools {
     clangTidyUrl=https://clrjit.blob.core.windows.net/clang-tools/${info}/clang-tidy
 
     if validate_url "$clangTidyUrl" > /dev/null; then
-        echo "Downloading clang-tidy to bin directory"
+        echo "Downloading clang-tidy to bin directory from:  $clangTidyUrl"
         # download appropriate version of clang-tidy
         if (( _machineHasCurl == 1 )); then
             curl --retry 4 --progress-bar --location --fail "$clangTidyUrl" -o bin/clang-tidy

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,6 +52,7 @@ function validate_url {
         status="${response[1]}"
     fi
 
+    echo "validate_url status: $status"
     if (( status >= 200 || status < 400 )); then
         return 0;
     else


### PR DESCRIPTION
The `clang-format` and `clang-tidy` tool is failing to download although `validate_url` is not complaining about the url. I am guessing the latest dotnet arcade in https://github.com/dotnet/runtime/pull/84698 might have broken the `dotnet --info | grep RID` output because of which we might not be populating the url correctly. Added some logging.

Related: https://github.com/dotnet/runtime/issues/84780