### PR TITLE
Pass "-cross" arg on linux builds

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -300,7 +300,11 @@ namespace ManagedCodeGen
                         if (!File.Exists(Path.Combine(compileCommandsPath)))
                         {
                             Console.WriteLine("Can't find compile_commands.json file. Running configure.");
-                            string[] commandArgs = { _arch, _build, "configureonly", "-cmakeargs", "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" };
+                            List<string> commandArgs = new() { _arch, _build, "configureonly", "-cmakeargs", "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" };
+                            if (_os.ToLower() == "linux")
+                            {
+                                commandArgs.Add("-cross");
+                            }
                             string buildPath = Path.Combine(_rootPath, "build-runtime.sh");
 
                             if (_verbose)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84780. Tested by hooking up the changes locally with runtime's `jitformat.py` and running `python3 ./src/coreclr/scripts/jitformat.py -c /runtime/src/coreclr -o linux -a x64` in our mariner build container.

This might break scenarios where jitutils are used outside of ci on a non-mariner build image. Per discussion with @BruceForstall let's make a quick fix to unblock ci, and if this is problematic we could for example add an extra argument that controls whether the `-cross` argument is passed to the runtime build.

For context, the `-cross` argument is necessary after https://github.com/dotnet/runtime/pull/84148 because our linux build images have change from centos 7 to CBL-mariner, and the linux builds are now cross-builds that use a rootfs (even x64 and x64-musl).