### PR TITLE
Support jit-analyze being explicitly passed single files of different names

### DIFF
--- a/src/jit-analyze/Program.cs
+++ b/src/jit-analyze/Program.cs
@@ -252,7 +252,7 @@ namespace ManagedCodeGen
                 return Directory.EnumerateFiles(fullRootPath, searchPattern, searchOption)
                          .AsParallel().Select(p => new FileInfo
                          {
-                             name = Path.GetFileName(fullRootPath),
+                             name = p.Substring(fullRootPath.Length).TrimStart(Path.DirectorySeparatorChar),
                              methodList = ExtractMethodInfo(p)
                          }).ToList();
             }


### PR DESCRIPTION
The documentation says that passing jit-analyze two file paths instead of directories is supported, but the code did not know which two files to compare in the case where they had different names.

Example. Before:
```powershell
❯ jit-analyze --base "C:\dev\dotnet\perf-diff-finder\results\System.Tests.Perf_String.CtorCharCount(size__100)\base.dasm" --diff "C:\dev\dotnet\perf-diff-finder\results\System.Tests.Perf_String.CtorCharCount(size__100)\diff.dasm" --warn
Found 1 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Warning: the base metric is 0, the diff metric is 0, have you used a release version?


0 total files with Code Size differences (0 improved, 0 regressed), 0 unchanged.

0 total methods with Code Size differences (0 improved, 0 regressed), 0 unchanged.

--------------------------------------------------------------------------------
Warning: 1 files in base but not in diff.

Only in base files:
base.dasm
Warning: 1 files in diff but not in base.

Only in diff files:
diff.dasm
```

After:
```powershell
❯  jit-analyze --base "C:\dev\dotnet\perf-diff-finder\results\System.Tests.Perf_String.CtorCharCount(size__100)\base.dasm" --diff "C:\dev\dotnet\perf-diff-finder\results\System.Tests.Perf_String.CtorCharCount(size__100)\diff.dasm" --warn
Found 1 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3767
Total bytes of diff: 3767
Total bytes of delta: 0 (0.00 % of base)


0 total files with Code Size differences (0 improved, 0 regressed), 1 unchanged.

0 total methods with Code Size differences (0 improved, 0 regressed), 5 unchanged.

--------------------------------------------------------------------------------
```