### PR TITLE
Fixup URLs in comments and docs

### DIFF
--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -138,7 +138,7 @@ echo jit-format requires clang-format and clang-tidy version 3.8.*. Currently in
 clang-format --version
 clang-tidy --version
 echo Please install version 3.8.* and put the tools on the PATH to use jit-format.
-echo Tools can be found at http://llvm.org/releases/download.html#3.8.0
+echo Tools can be found at https://llvm.org/releases/download.html#3.8.0
 
 :DownloadTools
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -119,7 +119,7 @@ function download_tools {
 
     if [ ! -f bin/clang-format -o ! -f bin/clang-tidy ]; then
         echo "Either clang-tidy or clang-format was not installed. Please install and put them on the PATH to use jit-format."
-        echo "Tools can be found at http://llvm.org/releases/download.html#3.8.0"
+        echo "Tools can be found at https://llvm.org/releases/download.html#3.8.0"
         return 1
     fi
 
@@ -135,7 +135,7 @@ get_host_os
 # Check if our required tools exist.
 
 if ! hash dotnet 2>/dev/null; then
-    echo "${__ErrMsgPrefix}Can't find dotnet! Please install from http://dot.net and add to PATH."
+    echo "${__ErrMsgPrefix}Can't find dotnet! Please install from https://dot.net and add to PATH."
     exit 1
 fi
 

--- a/doc/cijobs.md
+++ b/doc/cijobs.md
@@ -30,7 +30,7 @@ The "cijobs list" command has the following help message:
                   [-n <arg>] [-l] [-c <arg>] [-a]
 
         -s, --server <arg>       Url of the server. Defaults to
-                                 http://ci.dot.net/
+                                 https://ci.dot.net/
         -j, --job <arg>          Name of the job.
         -b, --branch <arg>       Name of the branch (default is master).
         -r, --repo <arg>         Name of the repo (e.g. dotnet_corefx or
@@ -48,7 +48,7 @@ The "cijobs copy" command has the following help message:
                   [-r <arg>] [-o <arg>] [-u] [-p <arg>]
 
         -s, --server <arg>         Url of the server. Defaults to
-                                   http://ci.dot.net/
+                                   https://ci.dot.net/
         -j, --job <arg>            Name of the job.
         -n, --number <arg>         Job number.
         -l, --last_successful      Copy last successful build.

--- a/doc/cijobs.md
+++ b/doc/cijobs.md
@@ -15,8 +15,8 @@ cijobs help message:
     $ cijobs --help
     usage: cijobs <command> [<args>]
 
-        list    List jobs on dotnet-ci.cloudapp.net for the repo.
-        copy    Copies job artifacts from dotnet-ci.cloudapp.net. This
+        list    List jobs on ci.dot.net for the repo.
+        copy    Copies job artifacts from ci.dot.net. This
                 command copies a zip of artifacts from a repo (defaulted to
                 dotnet_coreclr). The default location of the zips is the
                 Product sub-directory, though that can be changed using the

--- a/doc/formatting.md
+++ b/doc/formatting.md
@@ -139,7 +139,7 @@ jit-format uses clang-format and clang-tidy to do its work.
 Currently, clang-tidy will run the `modernize-use-nullptr` and `readability-braces`
 checks. Clang-format will use the `.clang-format` specification found in the jit directory.
 A summary of what each of the options does can be found
-[here](http://llvm.org/releases/3.8.0/tools/clang/docs/ClangFormatStyleOptions.html).
+[here](https://llvm.org/releases/3.8.0/tools/clang/docs/ClangFormatStyleOptions.html).
 
 Because jit-format will build a `compile_commands.json` database from the build log on Windows,
 developers must do a full build of coreclr before running jit-format.

--- a/src/cijobs/CIJobsRootCommand.cs
+++ b/src/cijobs/CIJobsRootCommand.cs
@@ -45,7 +45,7 @@ namespace ManagedCodeGen
         {
             List<string> errors = new();
 
-            CliCommand listCommand = new("list", "List jobs on dotnet-ci.cloudapp.net for the repo.")
+            CliCommand listCommand = new("list", "List jobs on ci.dot.net for the repo.")
             {
                 Server,
                 JobName,
@@ -104,7 +104,7 @@ namespace ManagedCodeGen
 
             Subcommands.Add(listCommand);
 
-            CliCommand copyCommand = new("copy", @"Copies job artifacts from dotnet-ci.cloudapp.net. This
+            CliCommand copyCommand = new("copy", @"Copies job artifacts from ci.dot.net. This
 command copies a zip of artifacts from a repo (defaulted to
 dotnet_coreclr). The default location of the zips is the
 Product sub-directory, though that can be changed using the

--- a/src/cijobs/CIJobsRootCommand.cs
+++ b/src/cijobs/CIJobsRootCommand.cs
@@ -13,7 +13,7 @@ namespace ManagedCodeGen
     internal sealed class CIJobsRootCommand : CliRootCommand
     {
         public CliOption<string> Server { get; } =
-            new("--server", "-s") { Description = "Url of the server. Defaults to http://ci.dot.net/" };
+            new("--server", "-s") { Description = "Url of the server. Defaults to https://ci.dot.net/" };
         public CliOption<string> JobName { get; } =
             new("--job", "-j") { Description = "Name of the job." };
         public CliOption<string> BranchName { get; } =

--- a/src/mutate-test/Program.cs
+++ b/src/mutate-test/Program.cs
@@ -25,7 +25,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 // * Try random stuff from https://github.com/dotnet/roslyn-sdk/tree/master/samples/CSharp/TreeTransforms
 // * Consider making the mutated assemblies unloadable?
 //
-// See http://roslynquoter.azurewebsites.net/ for tool that shows how use roslyn APIs for C# syntax.
+// See https://roslynquoter.azurewebsites.net/ for tool that shows how use roslyn APIs for C# syntax.
 // Useful if you can express what you want in C# and need to see how to get a transform to create it for you.
 
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;


### PR DESCRIPTION
- Use https: instead of http: where the remote server honors https (basically, every place that's not an XML namespace URI)
- Remove stale references to dotnet-ci.cloudapp.net