### PR TITLE
Add option to enable Linux cross builds for jit-format.

### DIFF
--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -40,6 +40,7 @@ namespace ManagedCodeGen
             private string _srcDirectory = null;
             private bool _untidy = false;
             private bool _noformat = false;
+            private bool _linuxCross = false;
             private bool _fix = false;
             private bool _verbose = false;
             private bool _ignoreErrors = false;
@@ -63,13 +64,14 @@ namespace ManagedCodeGen
                     syntax.DefineOption("v|verbose", ref _verbose, "Enable verbose output.");
                     syntax.DefineOption("untidy", ref _untidy, "Do not run clang-tidy");
                     syntax.DefineOption("noformat", ref _noformat, "Do not run clang-format");
+                    syntax.DefineOption("l|linux-cross", ref _linuxCross, "If on Linux, run the configure build as a cross build.");
                     syntax.DefineOption("f|fix", ref _fix, "Fix formatting errors discovered by clang-format and clang-tidy.");
                     syntax.DefineOption("i|ignore-errors", ref _ignoreErrors, "Ignore clang-tidy errors");
                     syntax.DefineOptionList("projects", ref _projects, "List of build projects clang-tidy should consider (e.g. dll, standalone, protojit, etc.). Default: dll");
 
                     syntax.DefineParameterList("filenames", ref _filenames, "Optional list of files that should be formatted.");
                 });
-                
+
                 // Run validation code on parsed input to ensure we have a sensible scenario.
 
                 validate();
@@ -301,7 +303,7 @@ namespace ManagedCodeGen
                         {
                             Console.WriteLine("Can't find compile_commands.json file. Running configure.");
                             List<string> commandArgs = new() { _arch, _build, "configureonly", "-cmakeargs", "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" };
-                            if (_os.ToLower() == "linux")
+                            if (_os.ToLower() == "linux" && _linuxCross)
                             {
                                 commandArgs.Add("-cross");
                             }


### PR DESCRIPTION
Currently, when jit-format attempts to build a fresh version of compile-commands.json on Linux, it will always attempt a cross build, regardless of whether this is accurate for the host system. This currently breaks our internal formatting CI, as there is no way to disable this with an option/configuration flag. 

This patch adds an option to enable cross builds when on Linux, rather than defaulting to always building with -cross.

I think this will likely break the current .NET CI though, as viewing the [prior patch](https://github.com/dotnet/jitutils/commit/0eb1143e2e6c85d1ea3a999c1be627473a9f7e50) which introduced this argument indicates this was a quick fix to unblock CI after it moved to using rootfs on Mariner, requiring -cross. If this patch is applied, `--linux-cross` would have to be passed.