### PR TITLE
Update for new categories of tiered compilation

### DIFF
--- a/src/instructions-retired-explorer/instructions-retired-explorer.csproj
+++ b/src/instructions-retired-explorer/instructions-retired-explorer.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fix instructions retired explorer to understand new categories of jitted code introduced in .NET 8.

Use proper event field rather than trying to decode flags.

Update trace event to a version with the new OptimizationTier values.