### PR TITLE
Adding a fallback for the platform if it couldn't be detected from dotnet --info

### DIFF
--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -310,6 +310,24 @@ namespace ManagedCodeGen
                     Console.WriteLine("{0}", result.StdOut);
                     Console.WriteLine("stderr:");
                     Console.WriteLine("{0}", result.StdErr);
+
+                    if (OperatingSystem.IsWindows())
+                    {
+                        _platformName = "Windows";
+                    }
+                    else if (OperatingSystem.IsLinux())
+                    {
+                        _platformName = "Linux";
+                    }
+                    else if (OperatingSystem.IsMacOS())
+                    {
+                        _platformName = "Darwin";
+                    }
+
+                    if (_platformName != null)
+                    {
+                        Console.WriteLine($"Falling back to {_platformName} based on OS detection.");
+                    }
                 }
             }
 


### PR DESCRIPTION
Running `jit-diff` from the runtime root can fail due to the existence of the `globa.json` and custom SDK that is setup since the `Platform` line may not be printed in that scenario.

This adds some basic fallback logic to ensure we can still work in that scenario.