### PR TITLE
RLCSE: streaming SPMI mode

### DIFF
--- a/src/jit-rl-cse/MLCSECommands.cs
+++ b/src/jit-rl-cse/MLCSECommands.cs
@@ -113,7 +113,14 @@ public class MLCSECommands : CliRootCommand
     // Crosscutting
     //
     public CliOption<bool> ShowSPMIRuns { get; } =
-    new("--showSPMIRuns") { Description = "show each SPMI invocation" };
+        new("--showSPMIRuns") { Description = "show each SPMI invocation" };
+
+    public CliOption<bool> StreamSPMI { get; } =
+        new("--streamSPMI") { Description = "use streaming mode for per-method SPMI requests" };
+    public CliOption<bool> LogSPMI { get; } =
+        new("--logSPMI") { Description = "write log of spmi activity to output dir" };
+    public CliOption<bool> StatsSPMI { get; } =
+        new("--statsSPMI") { Description = "dump server stats each summary interval" };
 
     public ParseResult? Result;
 
@@ -170,6 +177,9 @@ public class MLCSECommands : CliRootCommand
         Options.Add(SaveDumps);
 
         Options.Add(ShowSPMIRuns);
+        Options.Add(StreamSPMI);
+        Options.Add(LogSPMI);
+        Options.Add(StatsSPMI);
 
         SetAction(result =>
         {


### PR DESCRIPTION
Add support to use streaming SPMI servers. When enabled, RLCSE will launch one SPMI server process per core. Work dispatched to servers picks an idle server from the pool of servers. This greatly reduces the overhead of doing single-method evaluations.

SPMI streaming mode requires the changes in dotnet/runtime#98440.

Update the main Policy graident work loop and the greedy status loop to use the streaming mode, if enabled. MCMC can leverage this too, but I haven't done that just yet.

Add the ability to track server status.

Add the ability to log the server activity. The intent is that these logs can be replayed by a server instance to diagnose problems. This was useful during bring-up.

Add a running log of the Policy Gradient parameter values, so we can see how they change over time.

Refactor out some of the code in the main Policy Gradient loops.