### PR TITLE
[RISC-V] Add LLVM subarch features for RISC-V GC

### DIFF
--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -371,6 +371,8 @@ bool CorDisasm::init() {
 
   if (TheTargetArch == Target_Arm64) {
     Mcpu = "neoverse-n2";
+  } else if (TheTargetArch == Target_RiscV64) {
+    FeaturesStr = "+m,+a,+f,+d,+c,+zicsr,+zifencei";  // RV64GC
   }
 
   STI.reset(TheTarget->createMCSubtargetInfo(TargetTriple, Mcpu, FeaturesStr));


### PR DESCRIPTION
Without them only instructions from "I" base extension were recognized in disassembly.

Part of dotnet/runtime#84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @Bajtazar @bartlomiejko @rzsc