### PR TITLE
add instruction dump if decoding fails

### DIFF
--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -433,12 +433,11 @@ bool CorDisasm::decodeInstruction(BlockIterator &BIter, bool MayFail) const {
 
   if (!IsDecoded) {
     if (!MayFail) {
-      uint64_t InstSize = BIter.InstrSize;
       string buffer;
       raw_string_ostream OS(buffer);
 
       OS << format("%" PRIxPTR ": ", BIter.Addr);
-      dumpBytes(ArrayRef<uint8_t>(BIter.Ptr, InstSize), OS);
+      dumpBytes(ArrayRef<uint8_t>(BIter.Ptr, BIter.InstrSize), OS);
 
       Print->Error("Decode Failure %s@ offset:instr %s", BIter.Name, OS.str().c_str());
     }

--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -432,10 +432,18 @@ bool CorDisasm::decodeInstruction(BlockIterator &BIter, bool MayFail) const {
                                    BIter.Addr, CommentStream);
 
   if (!IsDecoded) {
-    BIter.InstrSize = 0;
     if (!MayFail) {
-      Print->Error("Decode Failure %s@ offset %8llx", BIter.Name, BIter.Addr);
+      uint64_t InstSize = BIter.InstrSize;
+      string buffer;
+      raw_string_ostream OS(buffer);
+
+      OS << format("%" PRIxPTR ": ", BIter.Addr);
+      dumpBytes(ArrayRef<uint8_t>(BIter.Ptr, InstSize), OS);
+
+      Print->Error("Decode Failure %s@ offset:instr %s", BIter.Name, OS.str().c_str());
     }
+
+    BIter.InstrSize = 0;
   } else {
     assert((BIter.InstrSize <= BIter.BlockSize) && "Invalid Decode");
     assert(BIter.InstrSize > 0 && "Zero Length Decode");


### PR DESCRIPTION
If decoding of instruction fails, `libcoredistools` will dump this instruction in hex. Normally, finding the source of `Decode Failure` is pretty tedious (especially for someone new). My code is analogous to `dumpInstruction(...)` implementation.

Part of dotnet/runtime#84834, cc @dotnet/samsung