### PR TITLE
[RISC-V] Add RVA profiles to coredistools

### DIFF
--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -375,7 +375,10 @@ bool CorDisasm::init() {
     // string "+all" to just enable all features, even those not implemented in any current CPU.
     FeaturesStr = "+all";
   } else if (TheTargetArch == Target_RiscV64) {
-    FeaturesStr = "+m,+a,+f,+d,+c,+zicsr,+zifencei";  // RV64GC
+    FeaturesStr = "+m,+a,+f,+d,+c,+zicsr,+zifencei,"  // RV64GC
+      "+zicntr,+zihpm,+ziccif,+ziccrse,+ziccamoa,+zicclsm,+za64rs,"  // RVA20
+      "+b,+zihintpause,+zic64b,+zicbom,+zicbop,+zicboz,+zfhmin,+zkt," // RVA22 mandatory
+      "+v,+zfh,+zkn,+zks"; // RVA22 optional
   }
 
   STI.reset(TheTarget->createMCSubtargetInfo(TargetTriple, Mcpu, FeaturesStr));


### PR DESCRIPTION
Add extensions of ratified RISC-V application profiles (the unprivileged side). JIT doesn't emit code for newly added extensions yet, this is to future-proof since coredistools are rebuilt infrequently. See https://github.com/dotnet/jitutils/issues/414#issuecomment-2358303120 for context.

Part of dotnet/runtime#84834, cc @dotnet/samsung @BruceForstall 