### PR TITLE
Pad RISC-V RVC instructions like Thumb2

### DIFF
--- a/src/coredistools/coredistools.cpp
+++ b/src/coredistools/coredistools.cpp
@@ -523,8 +523,9 @@ void CorDisasm::dumpInstruction(const BlockIterator &BIter) const {
                              "                  "};
     OS << (Padding[(InstSize < 7) ? (7 - InstSize) : 0]);
   }
-  else if (TheTargetArch == Target_Thumb) {
+  else if ((TheTargetArch == Target_Thumb) || (TheTargetArch == Target_RiscV64)) {
     // Thumb-2 encoding has 32-bit instructions and 16-bit instructions.
+    // RISC-V RVC has 32-bit instructions and 16-bit instructions.
     if (InstSize == 2) {
       OS << "      ";
     }


### PR DESCRIPTION
We're introducing RVC instructions to RISC-V JIT in dotnet/runtime: https://github.com/dotnet/runtime/pull/117408

With that PR and this PR, output of `R2RDump` tool for the following C# method:

```cs
public static long FunAdd(long a, long b)
{
        return a + b;
}
```

is as follows:

```asm
long Program.FunAdd(long, long)
Handle: 0x06000002
Rid: 2
EntryPointRuntimeFunctionId: 1
Number of RuntimeFunctions: 1

long Program.FunAdd(long, long)
Id: 1
StartAddress: 0x00010BD0
Size: 34 bytes
UnwindRVA: 0x0001091C

Debug Info
    Bounds:
    Native Offset: 0x0, Prolog, Source Types: StackEmpty
    Native Offset: 0x10, IL Offset: 0x0000, Source Types: StackEmpty
    Native Offset: 0x12, Epilog, Source Types: StackEmpty

    Variable Locations:
    Variable Number: 0
    Start Offset: 0x0
    End Offset: 0x10
    Loc Type: VLT_REG
    Register: A0

    Variable Number: 1
    Start Offset: 0x0
    End Offset: 0x10
    Loc Type: VLT_REG
    Register: A1

10bd0: 13 01 01 ff     addi    sp, sp, -16
10bd4: 23 30 81 00     sd      s0, 0(sp)
10bd8: 23 34 11 00     sd      ra, 8(sp)
10bdc: 13 04 01 00     mv      s0, sp
10be0: 2e 95           add     a0, a0, a1 ;; RVC instruction
10be2: 83 30 81 00     ld      ra, 8(sp)
10be6: 03 34 01 00     ld      s0, 0(sp)
10bea: 13 01 01 01     addi    sp, sp, 16
10bee: 67 80 00 00     ret
```