### PR TITLE
Bump coredistools version to 1.6

### DIFF
--- a/src/coredistools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
+++ b/src/coredistools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.NETCore.CoreDisTools</id>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
To pick up recent build changes enabling /guard:cf.