### PR TITLE
Update README to clarify ulimit requirement on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Current tools include:
     cd jitutils
     bootstrap.cmd
 ```
-(on non-Windows, run bootstrap.sh. NOTE: On Mac, you need to first use `ulimit -n 2048` or the `dotnet restore` part of the build will fail.)
+(on non-Windows, run bootstrap.sh.
+**macOS note:** On macOS versions **prior to 14 (Sonoma)** you must first run `ulimit -n 2048`, otherwise the `dotnet restore` part of the build may fail due to the lower default file descriptor limit.)
 
 4. Optionally, add the built tools directory to your path, e.g.:
 ```


### PR DESCRIPTION
This PR updates the `README.md` to clarify that raising the file descriptor limit with:

```sh
ulimit -n 2048
```

is only required on macOS versions prior to 14 (Sonoma).

* Older macOS releases default to a soft limit of 256 file descriptors, which can cause dotnet restore to fail during the bootstrap.sh build.
* Starting with macOS 14 (Sonoma), the default soft limit was increased to 2560, so manually setting the limit is no longer necessary.
