### PR TITLE
Fix warning `CS8981`

### DIFF
--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -130,7 +130,7 @@ namespace ManagedCodeGen
         }
     }
 
-    public partial class jitdiff
+    public partial class @jitdiff
     {
         public class DasmResult
         {

--- a/src/jit-diff/install.cs
+++ b/src/jit-diff/install.cs
@@ -18,7 +18,7 @@ using System.Xml;
 
 namespace ManagedCodeGen
 {
-    public partial class jitdiff
+    public partial class @jitdiff
     {
         public static int InstallCommand(Config config)
         {

--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -25,7 +25,7 @@ namespace ManagedCodeGen
         public string OutputPath { get; set; }
     }
 
-    public partial class jitdiff
+    public partial class @jitdiff
     {
         // Supported commands.  List to view information from the CI system, and Copy to download artifacts.
         public enum Commands

--- a/src/jit-diff/uninstall.cs
+++ b/src/jit-diff/uninstall.cs
@@ -11,7 +11,7 @@ using System.Text.Json.Nodes;
 
 namespace ManagedCodeGen
 {
-    public partial class jitdiff
+    public partial class @jitdiff
     {
         public static int UninstallCommand(Config config)
         {

--- a/src/jit-format/jit-format.cs
+++ b/src/jit-format/jit-format.cs
@@ -22,7 +22,7 @@ using System.Xml;
 
 namespace ManagedCodeGen
 {
-    public class jitformat
+    public class @jitformat
     {
         // Define options to be parsed 
         public class Config


### PR DESCRIPTION
Fix warning [CS8981: The type name only contains lower-cased ascii characters](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves#:~:text=CS8981%20%2D%20The%20type%20name%20only%20contains%20lower%2Dcased%20ascii%20characters).

This warning is a warning wave 7 diagnostic added in C# 11.

Fixes: https://github.com/dotnet/jitutils/issues/428.