### PR TITLE
Add updated R2R analysis

### DIFF
--- a/src/instructions-retired-explorer/instructions-retired-explorer.cs
+++ b/src/instructions-retired-explorer/instructions-retired-explorer.cs
@@ -486,7 +486,7 @@ namespace CoreClrInstRetired
         static void FixR2RLengths()
         {
             List<ImageInfo> r2rMethodImages = new List<ImageInfo>();
-            List<ImageInfo> r2rAssembyImages = new List<ImageInfo>();
+            List<ImageInfo> r2rAssemblyImages = new List<ImageInfo>();
             foreach (ImageInfo i in ImageMap.Values)
             {
                 // When parsing ETL, we used size zero for methods whose size were not known.
@@ -501,12 +501,12 @@ namespace CoreClrInstRetired
                     // This might be a native image containing R2R method images. Remember it so
                     // we can determine the size of the last method in the assembly.
                     //
-                    r2rAssembyImages.Add(i);
+                    r2rAssemblyImages.Add(i);
                 }
             }
 
             ImageInfo[] methodArray = r2rMethodImages.ToArray();
-            ImageInfo[] assemblyArray = r2rAssembyImages.ToArray();
+            ImageInfo[] assemblyArray = r2rAssemblyImages.ToArray();
 
             Array.Sort(methodArray, ImageInfo.LowerAddress);
             Array.Sort(assemblyArray, ImageInfo.LowerAddress);

--- a/src/instructions-retired-explorer/instructions-retired-explorer.cs
+++ b/src/instructions-retired-explorer/instructions-retired-explorer.cs
@@ -492,7 +492,7 @@ namespace CoreClrInstRetired
                 // When parsing ETL, we used size zero for methods whose size were not known.
                 // Collect these up so we can determine an approximate size (good enough for sample attribution).
                 //
-                if (i.IsJitGeneratedCode && i.Tier == OptimizationTier.ReadyToRun && i.Size == 1)
+                if (i.IsJitGeneratedCode && i.Tier == OptimizationTier.ReadyToRun && i.Size == 0)
                 {
                     r2rMethodImages.Add(i);
                 }


### PR DESCRIPTION
We no longer get method load events for R2R methods, but there are events that are fired when the runtime goes to find an R2R entry point that are almost as good. Enable these via `-RuntimeLoading` command line arg to perfview.

Add support for parsing these events and inferring the length of R2R methods from them.