### PR TITLE
Change jitdiff parallelism from coreCount * 2 to coreCount

### DIFF
--- a/src/jit-diff/diff.cs
+++ b/src/jit-diff/diff.cs
@@ -46,7 +46,7 @@ namespace ManagedCodeGen
             {
                 // We limit the number of tasks we start in parallel to avoid overwhelming the system.
                 // E.g. running frameworks diffs involves 100s of tasks, which can be problematic on machines with limited memory.
-                int parallelism = config.Sequential ? 1 : Environment.ProcessorCount * 2;
+                int parallelism = config.Sequential ? 1 : Environment.ProcessorCount;
 
                 bool anyFailed = false;
 


### PR DESCRIPTION
When diffing corelib+framework assemblies, the largest assemblies end up taking much longer than the rest, so by the end we're only jitting 1 or 2 dlls for a while. By turning parallelism down a bit, those large assemblies get more CPU time at the start, reducing the overall time to finish all of them.

I just did a quick test of before/after with MihuBot and it saves ~10 seconds (2m 40s => 2m 30s) on a 16-core VM when jitting two copies of runtime at the same time.
Could probably save a bit more by tweaking process priority / watching CPU usage, but this was a trivial change to make.