### PR TITLE
pmi: run all class constructors up front for deterministic -cctors output

### DIFF
--- a/src/pmi/pmi.cs
+++ b/src/pmi/pmi.cs
@@ -938,6 +938,108 @@ class Worker
         return maxResult;
     }
 
+    // When running with "cctors first", initialize every loaded type up front - before any method
+    // is JIT'd - rather than lazily / per-type. This covers the target assembly and every referenced
+    // assembly, most importantly System.Private.CoreLib. The JIT specializes codegen based on whether
+    // a referenced type is already initialized (initClass / getStaticFieldContent): when a type's
+    // .cctor has run it can drop class-init helpers, fold 'static readonly' fields and inline more
+    // aggressively. Whether some incidental or background-thread execution happened to run a given
+    // .cctor before a particular method was compiled is timing-dependent, which is the main source of
+    // non-deterministic PMI diffs under the parallel load of a jit-diff run. Forcing a fully and
+    // deterministically initialized class state removes that variability.
+    private void RunAllClassConstructorsFirst(Assembly target)
+    {
+        // Pull in the whole reference closure first so that types referenced only from method bodies
+        // (and therefore not necessarily loaded yet) are present and get initialized as well. This
+        // makes the set of initialized types a deterministic function of the assembly's metadata
+        // rather than of whatever happened to be loaded incidentally.
+        LoadReferenceClosure(target);
+
+        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                types = e.Types;
+            }
+            catch (Exception)
+            {
+                continue;
+            }
+
+            foreach (Type type in types)
+            {
+                // Open generic definitions cannot be initialized.
+                if (type == null || type.ContainsGenericParameters)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    RuntimeHelpers.RunClassConstructor(type.TypeHandle);
+                }
+                catch (Exception)
+                {
+                    // A .cctor may legitimately fail (e.g. platform-specific types); ignore it and keep
+                    // going so the remaining types are still initialized deterministically.
+                }
+            }
+        }
+    }
+
+    // Force the transitive closure of referenced assemblies to be loaded, using the target's load
+    // context so that PMIPATH resolution applies.
+    private static void LoadReferenceClosure(Assembly target)
+    {
+        AssemblyLoadContext context = AssemblyLoadContext.GetLoadContext(target) ?? AssemblyLoadContext.Default;
+        HashSet<string> seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        Stack<Assembly> pending = new Stack<Assembly>();
+
+        pending.Push(target);
+        seen.Add(target.GetName().Name);
+
+        while (pending.Count > 0)
+        {
+            Assembly assembly = pending.Pop();
+
+            AssemblyName[] references;
+            try
+            {
+                references = assembly.GetReferencedAssemblies();
+            }
+            catch (Exception)
+            {
+                continue;
+            }
+
+            foreach (AssemblyName reference in references)
+            {
+                if (reference.Name == null || !seen.Add(reference.Name))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    Assembly loaded = context.LoadFromAssemblyName(reference);
+                    if (loaded != null)
+                    {
+                        pending.Push(loaded);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Some references may be unresolvable in this environment; skip them.
+                }
+            }
+        }
+    }
+
     public int Work(string assemblyName)
     {
         string assemblyPath = Path.GetFullPath(assemblyName);
@@ -956,6 +1058,11 @@ class Worker
         }
 
         visitor.StartAssembly(assembly, assemblyPath);
+
+        if (compileAndInvokeCctorsFirst)
+        {
+            RunAllClassConstructorsFirst(assembly);
+        }
 
         bool keepGoing = true;
 


### PR DESCRIPTION
## Problem

PMI-based jit-diff (e.g. MihuBot's `-nuget` runs) produces noisy diffs even on PRs that change nothing — see https://github.com/MihuBot/runtime-utils/issues/1981. The diffs show types that are *randomly* already statically initialized (or not) by the time a method is compiled, which changes inlining, class-init helpers and `static readonly` folding between the base and diff runs.

## Root cause

The JIT specializes codegen based on whether a referenced type is already initialized (`initClass` / `getStaticFieldContent`): once a type's `.cctor` has run, the JIT can drop class-init helpers, fold `static readonly` fields and inline more aggressively. `PrepareMethod` itself does **not** run any `.cctor`, so the JIT observes whatever init state happened to exist incidentally at that moment (runtime startup, PMI's own reflection, background-thread activity). Under the parallel load of a jit-diff run that timing shifts, so the same method sees a type as initialized in one run and not in another — i.e. non-deterministic output.

## Fix

When PMI runs with `-cctors` (which MihuBot passes by default), initialize **every loaded type up front, before any method is JIT'd**, instead of lazily/per-type. This walks the target assembly's whole reference closure — most importantly `System.Private.CoreLib` — and runs every concrete type's `.cctor`. With all classes deterministically initialized, `initClass` consistently reports INITIALIZED and codegen no longer depends on init timing.

The existing per-type cctor path is kept because it also initializes the **closed generic instantiations** PMI creates during the walk (e.g. `Dictionary<string,int>`), which the up-front pass can't enumerate. The two are complementary.

Notes:
- Open generic definitions are skipped; `.cctor` failures are swallowed so initialization is exhaustive and order-independent.
- Only affects `-cctors` mode; default behavior is unchanged.
- The extra CoreLib methods jitted by running cctors are filtered out of the dasm by `DOTNET_JitDisasmAssemblies` in jit-dasm-pmi, so they don't appear in diffs.

cc @MihaZupan
